### PR TITLE
update cond qhgk: s_ij for crystal is antihermitian with purely imag …

### DIFF
--- a/kaldo/conductivity.py
+++ b/kaldo/conductivity.py
@@ -308,6 +308,10 @@ class Conductivity:
                         sij_right = phonon._sij_y
                     if beta == 2:
                         sij_right = phonon._sij_z
+                    if not phonons._is_amorphous:
+                        sij_right=np.conjugate(sij_right)
+
+
                     diffusivity = calculate_diffusivity(omega[k_index], sij_left, sij_right,
                                                         diffusivity_bandwidth[k_index],
                                                         physical_mode[k_index],


### PR DESCRIPTION
Solved issue about crystal thermal conductivity with qhgk wrong, often even negative. The generalized group velocity s_ij is an anti hermitian matrix for crystals. The formula should contain |s_ij|^2 not s_ij^2