### PR TITLE
solved issue storage harmonic_with_q_temperature

### DIFF
--- a/kaldo/observables/harmonic_with_q_temp.py
+++ b/kaldo/observables/harmonic_with_q_temp.py
@@ -15,19 +15,19 @@ class HarmonicWithQTemp(HarmonicWithQ):
             self.hbar = self.hbar * 1e-6
 
 
-    @lazy_property(label='<q_point>')
+    @lazy_property(label='<temperature>/<statistics>/<q_point>')
     def population(self):
         population = self._calculate_population()
         return population
 
 
-    @lazy_property(label='<q_point>')
+    @lazy_property(label='<temperature>/<statistics>/<q_point>')
     def heat_capacity(self):
         heat_capacity = self._calculate_heat_capacity()
         return heat_capacity
 
 
-    @lazy_property(label='<q_point>')
+    @lazy_property(label='<temperature>/<statistics>/<q_point>')
     def heat_capacity_2d(self):
         heat_capacity_2d = self._calculate_2d_heat_capacity()
         return heat_capacity_2d


### PR DESCRIPTION
For system with >1000 modes harmonic_with_q_temp stored the population and heat capacity under a label "q" instead of "q/temperature/statistics". This caused glasses (or super complex crystal with 1000 modes) to reuse the same population  for different temperature