### PR TITLE
Shengbte d3q

### DIFF
--- a/kaldo/forceconstants.py
+++ b/kaldo/forceconstants.py
@@ -89,7 +89,7 @@ class ForceConstants:
         supercell : (int, int, int), optional
             Number of unit cells in each cartesian direction replicated to form the input structure.
             Default is (1, 1, 1)
-        format : 'numpy', 'eskm', 'lammps', 'shengbte', 'shengbte-qe', 'hiphive'
+        format : 'numpy', 'eskm', 'lammps', 'shengbte', 'shengbte-qe','shengbte-d3q', 'hiphive'
             Format of force constant information being loaded into ForceConstants object.
             Default is 'numpy'
         third_energy_threshold : float, optional

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -112,7 +112,8 @@ class SecondOrder(ForceConstant):
                                        value=_second_order,
                                        is_acoustic_sum=is_acoustic_sum,
                                        folder=folder)
-        elif format == 'shengbte' or format == 'shengbte-qe':
+        #elif format == 'shengbte' or format == 'shengbte-qe':
+        elif format == 'shengbte' or format == 'shengbte-qe' or 'shengbte-d3q':
 
             config_file = folder + '/' + 'CONTROL'
             try:
@@ -124,7 +125,8 @@ class SecondOrder(ForceConstant):
 
             # Create a finite difference object
             # TODO: we need to read the grid type here
-            is_qe_input = (format == 'shengbte-qe')
+            #is_qe_input = (format == 'shengbte-qe')
+            is_qe_input = (format == 'shengbte-qe' or 'shengbte-d3q')
             n_replicas = np.prod(supercell)
             n_unit_atoms = atoms.positions.shape[0]
             if is_qe_input:
@@ -248,6 +250,7 @@ class SecondOrder(ForceConstant):
                 logging.info('Second order not found. Calculating.')
                 self.value = calculate_second(atoms, replicated_atoms, delta_shift, is_verbose)
                 self.save('second')
+                self.replicated_atoms.get_forces()
                 ase.io.write(self.folder + '/replicated_atoms.xyz', self.replicated_atoms, 'extxyz')
             else:
                 logging.info('Reading stored second')

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -102,19 +102,24 @@ class ThirdOrder(ForceConstant):
                                      folder=folder)
 
 
-        elif format == 'shengbte' or format == 'shengbte-qe':
+        #elif format == 'shengbte' or format == 'shengbte-qe':
+        elif format == 'shengbte' or format == 'shengbte-qe' or 'shengbte-d3q':
             grid_type='F'
             config_file = folder + '/' + 'CONTROL'
             try:
-                atoms, supercell = shengbte_io.import_control_file(config_file)
+                atoms, _supercell = shengbte_io.import_control_file(config_file)
+                #atoms, supercell = shengbte_io.import_control_file(config_file) #this was fixing the second and third supercell as equal
             except FileNotFoundError as err:
                 config_file = folder + '/' + 'POSCAR'
                 logging.info('\nTrying to open POSCAR')
                 atoms = ase.io.read(config_file)
 
             third_file = folder + '/' + 'FORCE_CONSTANTS_3RD'
-
-            third_order = shengbte_io.read_third_order_matrix(third_file, atoms, supercell, order='C')
+            if (format == 'shengbte' or format == 'shengbte-qe'  ):
+                third_order = shengbte_io.read_third_order_matrix(third_file, atoms, supercell, order='C')
+            else:
+                third_order = shengbte_io.read_third_d3q(third_file, atoms, supercell, order='C')
+            #third_order = shengbte_io.read_third_order_matrix(third_file, atoms, supercell, order='C')
             third_order = ThirdOrder.from_supercell(atoms=atoms,
                                                     grid_type=grid_type,
                                                     supercell=supercell,


### PR DESCRIPTION
Modification of the shengbte interface to read the 3rd forceconstant file from d3q. Now there are 3 shengbte formats: "shengbte", "shengbte-qe" and ""shengbte-d3q".
 Below there is a test on crystalline Germanium between d3q linewidths and kaldo linewidth computed using the interface. The subtle differences can likely be attributed to the different smearing methods in computing third_bandwidth.
Previous and obsolete branch read_d3q can be canceled now.
Please test it and also let me know if you think it is necessary to add an example.

![image (1)](https://github.com/nanotheorygroup/kaldo/assets/61904129/71772240-ecc5-46bf-a760-86ab11a4abad)

