### PR TITLE
Update doctools.js

### DIFF
--- a/docs/_static/doctools.js
+++ b/docs/_static/doctools.js
@@ -12,7 +12,8 @@
 /**
  * select a different prefix for underscore
  */
-$u = _.noConflict();
+/* $u = _.noConflict(); Experimentally commenting out this line to fix search function. This seems to set the underscore to a
+non standard function in javascript which breaks the search code. Unclear if this is a totally safe fix, needs testing! -N 7.9.2024 */
 
 /**
  * make the code below compatible with browsers without

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -13,11 +13,13 @@
       :toctree: API/
 
    {% for item in methods %}
-   {%- if not item.startswith('_') or item in ['__call__'] %}   ~{{ name }}.{{ item }}
+   {%- if not item.startswith('_') or item in ['__call__'] %}  ~{{ name }}.{{ item }}
    {% endif %}
    {%- endfor %}
+
    {% endif %}
    {% endblock %}
+
    {% block attributes %}
    {% if attributes %}
    .. rubric:: Properties

--- a/docs/_templates/autosummary/minimal_module.rst
+++ b/docs/_templates/autosummary/minimal_module.rst
@@ -3,6 +3,6 @@
 .. automodule:: {{ fullname }}
 
    {% block docstring %}
-   {% endblock %}
+   {% end block %}
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,10 +61,12 @@ extensions = [
 
 autosummary_generate = True
 autoclass_content = 'class'
+autodoc_member_order = 'bysource'
 
 #napoleon_google_docstring = False
 #napoleon_use_param = True
 #napoleon_use_ivar = True
+numpydoc_member_order = 'bysource'
 numpydoc_show_class_members = True
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False

--- a/docs/docsource/api_forceconstants.rst
+++ b/docs/docsource/api_forceconstants.rst
@@ -137,7 +137,7 @@ needed.
 .. _input-files:
 
 Input Files and Formats
------------------------
+=======================
 
 .. list-table:: Input Files
    :align: center
@@ -192,3 +192,5 @@ API Reference
 *************
 
 .. autoclass:: kaldo.forceconstants::ForceConstants
+    :members: from_folder
+

--- a/docs/docsource/api_phonons.rst
+++ b/docs/docsource/api_phonons.rst
@@ -14,8 +14,38 @@ initializing the Conductivity object.
 API Reference
 *************
 
-.. autoclass:: kaldo.phonons::Phonons
-   :members:
+.. rubric:: Methods
+
+.. autosummary::
+   :nosignatures:
+   :toctree: API/Phonons
+   :template: minimal_module.rst
+
+   Phonons.pdos
+
+.. rubric:: Attributes
+
+.. autosummary::
+  :nosignatures:
+  :toctree: API/Phonons
+  :template: minimal_module.rst
+
+   Phonons.physical_mode
+   Phonons.participation_ratio
+   Phonons.bandwidth
+   Phonons.isotopic_bandwidth
+   Phonons.anharmonic_bandwidth
+   Phonons.frequency
+   Phonons.omega
+   Phonons.velocity
+   Phonons.heat_capacity
+   Phonons.heat_capacity_2d
+   Phonons.population
+   Phonons.phase_space
+   Phonons.eigenvalues
+   Phonons.eigenvectors
+
+.. autoclass:: Phonons
 
 
    

--- a/kaldo/forceconstants.py
+++ b/kaldo/forceconstants.py
@@ -18,9 +18,8 @@ MAIN_FOLDER = 'displacement'
 
 class ForceConstants:
     """
-    Class for constructing the finite difference object to calculate
-    the second/third order force constant matrices after providing the
-    unit cell geometry and calculator information.
+    A ForceConstants class object is used to create or load the second or third order force constant matrices as well as
+    store information related to the geometry of the system.
 
     Parameters
     ----------
@@ -42,6 +41,10 @@ class ForceConstants:
         If the distance between two atoms exceeds threshold, the interatomic
         force is ignored.
         Defaults to `None`
+
+    Attributes
+    ----------
+
     """
 
     def __init__(self,
@@ -85,6 +88,17 @@ class ForceConstants:
         """
         Create a finite difference object from a folder
 
+        The folder should contain the a set of files whose names and contents are dependent on the "format" parameter.
+        Below is the list required for each format (also found in the api_forceconstants documentation if you prefer
+        to read it with nicer formatting and explanations).
+
+        numpy: replicated_atoms.xyz, second.npy, third.npz
+        eskm: CONFIG, replicated_atoms.xyz, Dyn.form, THIRD
+        lammps: replicated_atoms.xyz, Dyn.form, THIRD
+        shengbte: CONTROL, POSCAR, FORCE_CONSTANTS_2ND/FORCE_CONSTANTS, FORCE_CONSTANTS_3RD
+        shengbte-qe: CONTROL, POSCAR, espresso.ifc2, FORCE_CONSTANTS_3RD
+        hiphive: atom_prim.xyz, replicated_atoms.xyz, model2.fcs, model3.fcs
+
         Parameters
         ----------
         folder : str
@@ -98,7 +112,7 @@ class ForceConstants:
         third_energy_threshold : float, optional
             When importing sparse third order force constant matrices, energies below
             the threshold value in magnitude are ignored. Units: ev/A^3
-                Default is `None`
+            Default is `None`
         distance_threshold : float, optional
             When calculating force constants, contributions from atoms further than the
             distance threshold will be ignored.
@@ -108,15 +122,6 @@ class ForceConstants:
         is_acoustic_sum : Bool, optional
             If true, the acoustic sum rule is applied to the dynamical matrix.
             Default is False
-
-        Inputs
-        ------
-        numpy: replicated_atoms.xyz, second.npy, third.npz
-        eskm: CONFIG, replicated_atoms.xyz, Dyn.form, THIRD
-        lammps: replicated_atoms.xyz, Dyn.form, THIRD
-        shengbte: CONTROL, POSCAR, FORCE_CONSTANTS_2ND/FORCE_CONSTANTS, FORCE_CONSTANTS_3RD
-        shengbte-qe: CONTROL, POSCAR, espresso.ifc2, FORCE_CONSTANTS_3RD
-        hiphive: atom_prim.xyz, replicated_atoms.xyz, model2.fcs, model3.fcs
 
 
         Returns
@@ -214,7 +219,20 @@ class ForceConstants:
 
 
     def elastic_prop(self):
+        """
+        Return the stiffness tensor (aka elastic modulus tensor) of the system in GPa. This describes the stress-strain
+        relationship of the material and can sometimes be used as a loose predictor for thermal conductivity. Requires
+        the dynamical matrix to be loaded or calculated.
 
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        C_ijkl : np.array(3, 3, 3, 3)
+            Elasticity tensor in GPa
+        """
         # Intake key parameters
         atoms = self.atoms
         masses = atoms.get_masses()

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -143,10 +143,11 @@ class Phonons:
     def physical_mode(self):
         """Calculate physical modes. Non physical modes are the first 3 modes of q=(0, 0, 0) and, if defined, all the
         modes outside the frequency range min_frequency and max_frequency.
+
         Returns
         -------
-        physical_mode : np array
-            (n_k_points, n_modes) bool
+        physical_mode : np array(n_k_points, n_modes)
+            bool
         """
         q_points = self._reciprocal_grid.unitary_grid(is_wrapping=False)
         physical_mode = np.zeros((self.n_k_points, self.n_modes), dtype=bool)
@@ -173,10 +174,11 @@ class Phonons:
     @lazy_property(label='')
     def frequency(self):
         """Calculate phonons frequency
+
         Returns
         -------
-        frequency : np array
-            (n_k_points, n_modes) frequency in THz
+        frequency : np array(n_k_points, n_modes)
+             frequency in THz
         """
         q_points = self._reciprocal_grid.unitary_grid(is_wrapping=False)
         frequency = np.zeros((self.n_k_points, self.n_modes))
@@ -201,10 +203,11 @@ class Phonons:
         """Calculates the participation ratio of each normal mode. Participation ratio's
         represent the fraction of atoms that are displaced meaning a value of 1 corresponds
         to translation. Defined by equations in DOI: 10.1103/PhysRevB.53.11469
+
         Returns
         -------
-        participation_ratio : np array
-            (n_k_points, n_modes) atomic participation
+        participation_ratio : np array(n_k_points, n_modes)
+             atomic participation
         """
         q_points = self._reciprocal_grid.unitary_grid(is_wrapping=False)
         participation_ratio = np.zeros((self.n_k_points, self.n_modes))
@@ -230,8 +233,8 @@ class Phonons:
 
         Returns
         -------
-        velocity : np array
-            (n_k_points, n_unit_cell * 3, 3) velocity in 100m/s or A/ps
+        velocity : np array(n_k_points, n_unit_cell * 3, 3)
+             velocity in 100m/s or A/ps
         """
 
         q_points = self._reciprocal_grid.unitary_grid(is_wrapping=False)
@@ -257,9 +260,9 @@ class Phonons:
 
         Returns
         -------
-        _eigensystem : np.array(n_k_points, n_unit_cell * 3, n_unit_cell * 3 + 1)
+        _eigensystem : np.array(n_k_points, n_unit_cell * 3 + 1, n_unit_cell * 3)
             eigensystem is calculated for each k point, the three dimensional array
-            records the eigenvalues in the last column of the last dimension.
+            records the eigenvalues in the first column of the second dimension.
 
             If the system is not amorphous, these values are stored as complex numbers.
         """
@@ -398,10 +401,11 @@ class Phonons:
     def isotopic_bandwidth(self):
         """ Calculate the isotopic bandwidth with Tamura perturbative formula.
         Defined by equations in DOI:https://doi.org/10.1103/PhysRevB.27.858
+
         Returns
         -------
-        isotopic_bw : np array
-            (n_k_points, n_modes) atomic participation
+        isotopic_bw : np array(n_k_points, n_modes)
+             atomic participation
         """
         if self._is_amorphous:
             logging.warning('isotopic scattering not implemented for amorphous systems')
@@ -451,8 +455,8 @@ class Phonons:
 
         Returns
         -------
-        eigenvalues : np array
-            (n_phonons) Eigenvalues of the dynamical matrix
+        eigenvalues : np array(n_phonons)
+             Eigenvalues of the dynamical matrix
         """
         eigenvalues = self._eigensystem[:, 0, :]
         return eigenvalues
@@ -464,8 +468,8 @@ class Phonons:
 
         Returns
         -------
-        eigenvectors : np array
-            (n_phonons, n_phonons) Eigenvectors of the dynamical matrix
+        eigenvectors : np array(n_phonons, n_phonons)
+             Eigenvectors of the dynamical matrix
         """
         eigenvectors = self._eigensystem[:, 1:, :]
         return eigenvectors
@@ -497,8 +501,8 @@ class Phonons:
 
         Returns
         -------
-        frequency : np array
-            (n_k_points, n_modes) frequency in rad
+        frequency : np array(n_k_points, n_modes)
+            frequency in rad
         """
         return self.frequency * 2 * np.pi
 
@@ -530,8 +534,10 @@ class Phonons:
 
         Returns
         -------
-            freq, pdos : np array, np array
-            (n_points), (n_projections, n_points) Frequencies, pdos for each set of projected atoms`
+            frequency : np array(n_points)
+                Frequencies
+            pdos : np.array(n_projections, n_points)
+                pdos for each set of projected atoms and directions
         """
 
         p_single = False


### PR DESCRIPTION
This is a temporary solution to the broken search function. 

Search functionality is restored, however I don't know for certain whether it is a completely safe fix. No unit tests broken., but further testing required.

The .noConflict() that is called is apparently a way of restoring any variables that were "saved" when jquery starts running. see here- https://api.jquery.com/jQuery.noConflict/
However, in this instance it overwrites the value of the _ function jquery uses, which then breaks the search.
It doesn't seem that we need to restore any variables from "previously loaded javascript frameworks" (phrase from docs on noconflict) so this shouldn't be an issue, however it's unclear why it was added in the first place.
Closes #130 
