### PR TITLE
Added another safety check to pdos routine

### DIFF
--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -534,7 +534,9 @@ class Phonons:
             (n_points), (n_projections, n_points) Frequencies, pdos for each set of projected atoms`
         """
 
-        p_single = False
+        if p_atoms is None:
+          p_atoms = list(range(self.n_atoms))
+
         n_proj = len(p_atoms)
 
         if n_proj == 0:
@@ -547,7 +549,6 @@ class Phonons:
 
             except TypeError as e:
                 n_proj = 1
-                p_single = True
                 p_atoms = [p_atoms]
 
         n_modes = self.n_modes
@@ -559,7 +560,6 @@ class Phonons:
 
         fmin, fmax = frequency.min(), frequency.max()
 
-        # Extend the maximum and minimum of frequency to have the tail of pdos
         f_grid = np.linspace(0.9 * fmin, 1.1 * fmax, n_points)
 
         p_dos = np.zeros((n_proj,n_points), dtype=float)


### PR DESCRIPTION
Allow p_atoms to be passed to pdos routine as None, in which case the total phonon dos is calculated. Previously, this safety check was only done in kaldo/controllers/plotter.py, so there was no default behavior for unspecified p_atoms, if phonons.pdos was called directly by the user.