### PR TITLE
Updates to push to pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="docs/docsource/_resources/logo.png" width="450">
+<img src="https://raw.githubusercontent.com/nanotheorygroup/kaldo/main/docs/docsource/_resources/logo.png" width="450">
 
 [//]: # (Badges)
 [![CircleCI](https://img.shields.io/circleci/build/github/nanotheorygroup/kaldo/main)](https://app.circleci.com/pipelines/github/nanotheorygroup/kaldo)
@@ -44,8 +44,8 @@ Copyright (c) 2022, Giuseppe Barbalinardo, Zekun Chen, Dylan Folkner, Nicholas W
 We gratefully acknowledge support by the Investment Software Fellowships (grant No. ACI-1547580-479590) of the NSF Molecular Sciences Software Institute (grant No. ACI-1547580) at Virginia Tech. 
 
 <a href="https://molssi.org">
-<img src="docs/docsource/_resources/molssi-logo.png" height="120">  
-<img src="docs/docsource/_resources/nsf_logo.png" height="120">    
+<img src="https://raw.githubusercontent.com/nanotheorygroup/kaldo/main/docs/docsource/_resources/molssi-logo.png" height="120">  
+<img src="https://raw.githubusercontent.com/nanotheorygroup/kaldo/main/docs/docsource/_resources/nsf_logo.png" height="120">    
 </a>
  
 MolSSI builds open source software and data which serves the computational molecular science community. [Explore MolSSI’s software infrastructure projects.](https://molssi.org/software-projects/)

--- a/docs/docsource/getting_started.md
+++ b/docs/docsource/getting_started.md
@@ -12,7 +12,7 @@ conda install pip
 
 kALDo installation can be done using `pip`
 ```bash
-pip install git+https://github.com/nanotheorygroup/kaldo
+pip install kaldo
 ```
 
 #### Using `pip` and `virtualenv`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy==1.25.1
-protobuf==4.23.4
 scipy==1.11.1
 ase==3.22.1
 sparse>=0.11.2


### PR DESCRIPTION
Minor updates to improve the `pip install kaldo` process and clean up the documentation on `https://pypi.org/project/kaldo`.