### PR TITLE
Split third order calculation to run on a single nu (phonon index) at the time. 

### DIFF
--- a/kaldo/controllers/anharmonic.py
+++ b/kaldo/controllers/anharmonic.py
@@ -1,19 +1,37 @@
 """
 kaldo
 Anharmonic Lattice Dynamics
+
+This module contains functions for calculating anharmonic properties of phonons
+in both amorphous and crystalline materials.
 """
 import numpy as np
 import ase.units as units
-from kaldo.helpers.tools import timeit
 import tensorflow as tf
 from opt_einsum import contract
 from kaldo.helpers.logger import get_logger, log_size
+from kaldo.helpers.tools import timeit
 from kaldo.controllers.dirac_kernel import gaussian_delta, triangular_delta, lorentz_delta
+
 logging = get_logger()
+
+# Constants
+GAMMA_TO_THZ = 1e11 * units.mol * (units.mol / (10 * units.J)) ** 2
+HBAR = units._hbar
+THZ_TO_MEV = units.J * HBAR * 2 * np.pi * 1e15
 
 
 @timeit
 def project_amorphous(phonons):
+    """
+    Project anharmonic properties for amorphous materials.
+
+    Args:
+        phonons: Phonon object containing material properties
+
+    Returns:
+        np.ndarray: Array containing projected properties
+    """
     is_balanced = phonons.is_balanced
     frequency = phonons.frequency
     omega = 2 * np.pi * frequency
@@ -21,7 +39,6 @@ def project_amorphous(phonons):
     n_replicas = phonons.forceconstants.n_replicas
     rescaled_eigenvectors = phonons._rescaled_eigenvectors.astype(float)
 
-    # The ps and gamma matrix stores ps, gamma and then the scattering matrix
     ps_and_gamma = np.zeros((phonons.n_phonons, 2))
     evect_tf = tf.convert_to_tensor(rescaled_eigenvectors[0])
 
@@ -35,52 +52,77 @@ def project_amorphous(phonons):
     third_tf = tf.sparse.reshape(third_tf, ((phonons.n_modes * n_replicas) ** 2, phonons.n_modes))
     physical_mode = phonons.physical_mode.reshape((phonons.n_k_points, phonons.n_modes))
     logging.info('Projection started')
-    gamma_to_thz = 1e11 * units.mol * (units.mol / (10 * units.J)) ** 2
-    thztomev = units.J * phonons.hbar * 2 * np.pi * 1e15
+
+    hbar = HBAR * (1e-6 if phonons.is_classic else 1)
+
     for nu_single in range(phonons.n_phonons):
         sigma_tf = tf.constant(phonons.third_bandwidth, dtype=tf.float64)
 
-        out = calculate_dirac_delta_amorphous(omega,
-                                              population,
-                                              physical_mode,
-                                              sigma_tf,
-                                              phonons.broadening_shape,
-                                              nu_single,
-                                              is_balanced)
-        if not out:
-            continue
-        third_nu_tf = tf.sparse.sparse_dense_matmul(third_tf,
-                                                    tf.reshape(evect_tf[:, nu_single], ((phonons.n_modes, 1))))
-        third_nu_tf = tf.reshape(third_nu_tf,
-                                 (phonons.n_modes * n_replicas, phonons.n_modes * n_replicas))
+        ps_and_gamma[nu_single] = project_amorphous_mu(
+            omega, population, physical_mode, sigma_tf,
+            phonons.broadening_shape, nu_single, is_balanced,
+            third_tf, evect_tf, phonons.n_modes, n_replicas, hbar
+        )
 
-        dirac_delta_tf, mup_vec, mupp_vec = out
-        scaled_potential_tf = tf.einsum('ij,in,jm->nm', third_nu_tf, evect_tf, evect_tf)
-        coords = tf.stack((mup_vec, mupp_vec), axis=-1)
-        # pot_times_dirac_tf = tf.SparseTensor(coords, tf.abs(tf.gather_nd(scaled_potential_tf, coords)) ** 2 \
-        # * dirac_delta_tf, (n_phonons, n_phonons))
+    return ps_and_gamma
 
-        pot_times_dirac = tf.gather_nd(scaled_potential_tf,coords) **  2
-        pot_times_dirac = pot_times_dirac / tf.gather(omega[0], mup_vec) / tf.gather(omega[0], mupp_vec)
-        pot_times_dirac = tf.reduce_sum(tf.abs(pot_times_dirac) * dirac_delta_tf)
-        pot_times_dirac = np.pi * phonons.hbar / 4. * pot_times_dirac / phonons.n_k_points * gamma_to_thz
 
-        dirac_delta = tf.reduce_sum(dirac_delta_tf)
+def project_amorphous_mu(omega, population, physical_mode, sigma_tf, broadening_shape,
+                         nu_single, is_balanced, third_tf, evect_tf, n_modes, n_replicas, hbar):
+    """
+    Project anharmonic properties for a single mode in amorphous materials.
 
-        ps_and_gamma[nu_single, 0] = dirac_delta.numpy()
-        ps_and_gamma[nu_single, 1] = pot_times_dirac.numpy()
-        ps_and_gamma[nu_single, 1:] /= omega.flatten()[nu_single]
+    Args:
+        (various): Parameters describing the phonon properties and material
 
-        logging.info('calculating third ' + str(nu_single) + ': ' + str(np.round(nu_single / \
-                                                                                 phonons.n_phonons, 2) * 100) + '%')
-        logging.info(str(frequency.reshape(phonons.n_phonons)[nu_single]) + ': ' + \
-                     str(ps_and_gamma[nu_single, 1] * thztomev / (2 * np.pi)))
+    Returns:
+        np.ndarray: Projected properties for the single mode
+    """
+    if not physical_mode[0, nu_single]:
+        return np.zeros(2)
+
+    dirac_delta_result = calculate_dirac_delta_amorphous(
+        omega, population, physical_mode, sigma_tf,
+        broadening_shape, nu_single, is_balanced
+    )
+
+    if not dirac_delta_result:
+        return np.zeros(2)
+
+    dirac_delta_tf, mup_vec, mupp_vec = dirac_delta_result
+    dirac_delta = tf.reduce_sum(dirac_delta_tf)
+
+    third_nu_tf = tf.sparse.sparse_dense_matmul(third_tf,
+                                                tf.reshape(evect_tf[:, nu_single], ((n_modes, 1))))
+    third_nu_tf = tf.reshape(third_nu_tf,
+                             (n_modes * n_replicas, n_modes * n_replicas))
+
+    scaled_potential_tf = tf.einsum('ij,in,jm->nm', third_nu_tf, evect_tf, evect_tf)
+    coords = tf.stack((mup_vec, mupp_vec), axis=-1)
+    pot_times_dirac = tf.gather_nd(scaled_potential_tf, coords) ** 2
+    pot_times_dirac = pot_times_dirac / tf.gather(omega[0], mup_vec) / tf.gather(omega[0], mupp_vec)
+    pot_times_dirac = tf.reduce_sum(tf.abs(pot_times_dirac) * dirac_delta_tf)
+    pot_times_dirac = np.pi * hbar / 4. * pot_times_dirac * GAMMA_TO_THZ
+
+    ps_and_gamma = np.zeros(2)
+    ps_and_gamma[0] = dirac_delta.numpy()
+    ps_and_gamma[1] = pot_times_dirac.numpy()
+    ps_and_gamma[1] /= omega.flatten()[nu_single]
 
     return ps_and_gamma
 
 
 @timeit
 def project_crystal(phonons):
+    """
+    Project anharmonic properties for crystalline materials.
+
+    Args:
+        phonons: Phonon object containing material properties
+
+    Returns:
+        np.ndarray: Array containing projected properties
+    """
     is_balanced = phonons.is_balanced
     is_gamma_tensor_enabled = phonons.is_gamma_tensor_enabled
     n_replicas = phonons.forceconstants.third.n_replicas
@@ -104,11 +146,10 @@ def project_crystal(phonons):
     evect_tf = tf.convert_to_tensor(phonons._rescaled_eigenvectors)
     evect_tf = tf.cast(evect_tf, dtype=tf.complex128)
 
-    # The ps and gamma matrix stores ps, gamma and then the scattering matrix
     if is_gamma_tensor_enabled:
         shape = (phonons.n_phonons, 2 + phonons.n_phonons)
         log_size(shape, name='scattering_tensor')
-        ps_and_gamma = np.zeros(shape)
+        ps_and_gamma = np.zeros((phonons.n_phonons, 2 + phonons.n_phonons))
     else:
         ps_and_gamma = np.zeros((phonons.n_phonons, 2))
     second_minus = tf.math.conj(evect_tf)
@@ -118,102 +159,129 @@ def project_crystal(phonons):
     broadening_shape = phonons.broadening_shape
     physical_mode = phonons.physical_mode.reshape((phonons.n_k_points, phonons.n_modes))
     omega = phonons.omega
-    if not phonons.third_bandwidth:
-        velocity_tf = tf.convert_to_tensor(phonons.velocity)
-    gamma_to_thz = 1e11 * units.mol * (units.mol / (10 * units.J)) ** 2
+    velocity_tf = tf.convert_to_tensor(phonons.velocity)
+    cell_inv = phonons.forceconstants.cell_inv
+
+    hbar = HBAR * (1e-6 if phonons.is_classic else 1)
     for nu_single in range(phonons.n_phonons):
-        if nu_single % 200 == 0:
-            logging.info('Calculating third order projection ' + str(nu_single) +  ', ' + \
-                         str(np.round(nu_single / phonons.n_phonons, 2) * 100) + '%')
         index_k, mu = np.unravel_index(nu_single, (n_k_points, phonons.n_modes))
-        if is_sparse:
-            third_nu_tf = tf.sparse.sparse_dense_matmul(third_tf, evect_tf[index_k, :, mu, tf.newaxis])
+        index_kpp_full_plus = phonons._allowed_third_phonons_index(index_k, True)
+        index_kpp_full_minus = phonons._allowed_third_phonons_index(index_k, False)
+
+        ps_and_gamma[nu_single] = project_crystal_mu(
+            omega, population, physical_mode, broadening_shape,
+            nu_single, is_balanced, third_tf, evect_tf, n_k_points,
+            phonons.n_modes, n_replicas, is_sparse, is_gamma_tensor_enabled,
+            phonons.third_bandwidth, hbar, velocity_tf, _chi_k,
+            index_kpp_full_plus, index_kpp_full_minus, second_minus,
+            second_minus_chi, index_k, mu, phonons.kpts, cell_inv
+        )
+
+    return ps_and_gamma
+
+
+def project_crystal_mu(omega, population, physical_mode, broadening_shape,
+                       nu_single, is_balanced, third_tf, evect_tf, n_k_points,
+                       n_modes, n_replicas, is_sparse, is_gamma_tensor_enabled,
+                       third_bandwidth, hbar, velocity_tf, _chi_k,
+                       index_kpp_full_plus, index_kpp_full_minus, second_minus,
+                       second_minus_chi, index_k, mu, kpts, cell_inv):
+    """
+    Project anharmonic properties for a single mode in crystalline materials.
+
+    Args:
+        (various): Parameters describing the phonon properties and material
+
+    Returns:
+        np.ndarray: Projected properties for the single mode
+    """
+    if not physical_mode[index_k, mu]:
+        return np.zeros(2 + n_k_points * n_modes) if is_gamma_tensor_enabled else np.zeros(2)
+
+    ps_and_gamma = np.zeros(2 + n_k_points * n_modes) if is_gamma_tensor_enabled else np.zeros(2)
+
+    # Calculate third_nu_tf
+    if is_sparse:
+        third_nu_tf = tf.sparse.sparse_dense_matmul(third_tf, evect_tf[index_k, :, mu, tf.newaxis])
+    else:
+        third_nu_tf = contract('ijk,i->jk', third_tf, evect_tf[index_k, :, mu], backend='tensorflow')
+        third_nu_tf = tf.reshape(third_nu_tf, (n_replicas * n_replicas, n_modes, n_modes))
+
+    third_nu_tf = tf.cast(tf.reshape(third_nu_tf, (n_replicas, n_modes, n_replicas, n_modes)), dtype=tf.complex128)
+    third_nu_tf = tf.transpose(third_nu_tf, (0, 2, 1, 3))
+    third_nu_tf = tf.reshape(third_nu_tf, (n_replicas * n_replicas, n_modes, n_modes))
+
+    for is_plus in (0, 1):
+        index_kpp_full = index_kpp_full_plus if is_plus else index_kpp_full_minus
+        index_kpp_full = tf.cast(index_kpp_full, dtype=tf.int32)
+
+        # Calculate sigma
+        if third_bandwidth:
+            sigma_tf = tf.constant(third_bandwidth, dtype=tf.float64)
         else:
-            third_nu_tf = contract('ijk,i->jk', third_tf, evect_tf[index_k, :, mu], backend='tensorflow')
-            third_nu_tf = tf.reshape(third_nu_tf, (n_replicas * n_replicas, phonons.n_modes, phonons.n_modes))
+            sigma_tf = calculate_broadening(velocity_tf, cell_inv, kpts, index_kpp_full)
 
-        third_nu_tf = tf.cast(
-            tf.reshape(third_nu_tf, (n_replicas, phonons.n_modes, n_replicas, phonons.n_modes)),
-            dtype=tf.complex128)
-        third_nu_tf = tf.transpose(third_nu_tf, (0, 2, 1, 3))
-        third_nu_tf = tf.reshape(third_nu_tf, (n_replicas * n_replicas, phonons.n_modes, phonons.n_modes))
-        for is_plus in (0, 1):
-            index_kpp_full = phonons._allowed_third_phonons_index(index_k, is_plus)
-            index_kpp_full = tf.cast(index_kpp_full, dtype=tf.int32)
+        dirac_delta_result = calculate_dirac_delta_crystal(
+            omega, population, physical_mode, sigma_tf, broadening_shape,
+            index_kpp_full, index_k, mu, is_plus, is_balanced
+        )
 
-            if phonons.third_bandwidth:
-                sigma_tf = tf.constant(phonons.third_bandwidth, dtype=tf.float64)
-            else:
-                cellinv = phonons.forceconstants.cell_inv
-                k_size = phonons.kpts
-                sigma_tf = calculate_broadening(velocity_tf, cellinv, k_size, index_kpp_full)
+        if not dirac_delta_result:
+            continue
 
-            out = calculate_dirac_delta_crystal(omega,
-                                                population,
-                                                physical_mode,
-                                                sigma_tf,
-                                                broadening_shape,
-                                                index_kpp_full,
-                                                index_k,
-                                                mu,
-                                                is_plus,
-                                                is_balanced)
-            if not out:
-                continue
+        dirac_delta, index_kp_vec, mup_vec, index_kpp_vec, mupp_vec = dirac_delta_result
 
+        second, second_chi = (evect_tf, _chi_k) if is_plus else (second_minus, second_minus_chi)
+        third = tf.math.conj(tf.gather(evect_tf, index_kpp_full))
+        third_chi = tf.math.conj(tf.gather(_chi_k, index_kpp_full))
+
+        # Calculate pot_times_dirac
+        chi_prod = tf.einsum('kt,kl->ktl', second_chi, third_chi)
+        chi_prod = tf.reshape(chi_prod, (n_k_points, n_replicas ** 2))
+        scaled_potential = tf.tensordot(chi_prod, third_nu_tf, (1, 0))
+        scaled_potential = tf.einsum('kij,kim->kjm', scaled_potential, second)
+        scaled_potential = tf.einsum('kjm,kjn->kmn', scaled_potential, third)
+        scaled_potential = tf.gather_nd(scaled_potential, tf.stack([index_kp_vec, mup_vec, mupp_vec], axis=-1))
+
+        pot_times_dirac = tf.abs(scaled_potential) ** 2 * dirac_delta
+        nup_vec = index_kp_vec * omega.shape[1] + mup_vec
+        nupp_vec = index_kpp_vec * omega.shape[1] + mupp_vec
+        pot_times_dirac = tf.cast(pot_times_dirac, dtype=tf.float64)
+        pot_times_dirac = pot_times_dirac / tf.gather(omega.flatten(), nup_vec) / tf.gather(omega.flatten(), nupp_vec)
+
+        # Update ps_and_gamma
+        if is_gamma_tensor_enabled:
+            nup_vec = index_kp_vec * n_modes + mup_vec
+            nupp_vec = index_kpp_vec * n_modes + mupp_vec
+            result = tf.math.bincount(nup_vec, pot_times_dirac, n_k_points * n_modes)
             if is_plus:
-
-                second = evect_tf
-                second_chi = _chi_k
+                ps_and_gamma[2:] -= result
             else:
+                ps_and_gamma[2:] += result
+            result = tf.math.bincount(nupp_vec, pot_times_dirac, n_k_points * n_modes)
+            ps_and_gamma[2:] += result
 
-                second = second_minus
-                second_chi = second_minus_chi
+        ps_and_gamma[0] += tf.reduce_sum(dirac_delta) / n_k_points
+        ps_and_gamma[1] += tf.reduce_sum(pot_times_dirac)
 
-            third = tf.math.conj(tf.gather(evect_tf, index_kpp_full))
-            third_chi = tf.math.conj(tf.gather(_chi_k, index_kpp_full))
-            dirac_delta, index_kp_vec, mup_vec, index_kpp_vec, mupp_vec = out
+    # Finalize ps_and_gamma
+    ps_and_gamma[1:] /= omega.flatten()[nu_single]
+    ps_and_gamma[1:] *= np.pi * hbar / 4 / n_k_points * GAMMA_TO_THZ
 
-            # The ps and gamma array stores first ps then gamma then the scattering array
-            chi_prod = tf.einsum('kt,kl->ktl', second_chi, third_chi)
-            chi_prod = tf.reshape(chi_prod, (n_k_points, n_replicas ** 2))
-            scaled_potential = tf.tensordot(chi_prod, third_nu_tf, (1, 0))
-            scaled_potential = tf.einsum('kij,kim->kjm', scaled_potential, second)
-            scaled_potential = tf.einsum('kjm,kjn->kmn', scaled_potential, third)
-
-            scaled_potential = tf.gather_nd(scaled_potential, tf.stack([index_kp_vec, mup_vec, mupp_vec], axis=-1))
-            pot_times_dirac = tf.abs(
-                scaled_potential) ** 2 * dirac_delta
-
-            nup_vec = index_kp_vec * phonons.n_modes + mup_vec
-            nupp_vec = index_kpp_vec * phonons.n_modes + mupp_vec
-            pot_times_dirac = tf.cast(pot_times_dirac, dtype=tf.float64)
-            pot_times_dirac = pot_times_dirac / tf.gather(omega.flatten(), nup_vec) / tf.gather(omega.flatten(), nupp_vec)
-
-            if is_gamma_tensor_enabled:
-                # We need to use bincount together with fancy indexing here. See:
-                # https://stackoverflow.com/questions/15973827/handling-of-duplicate-indices-in-numpy-assignments
-
-                nup_vec = index_kp_vec * phonons.n_modes + mup_vec
-                nupp_vec = index_kpp_vec * phonons.n_modes + mupp_vec
-
-                result = tf.math.bincount(nup_vec, pot_times_dirac, phonons.n_phonons)
-                if is_plus:
-                    ps_and_gamma[nu_single, 2:] -= result
-                else:
-                    ps_and_gamma[nu_single, 2:] += result
-
-                result = tf.math.bincount(nupp_vec, pot_times_dirac, phonons.n_phonons)
-                ps_and_gamma[nu_single, 2:] += result
-            ps_and_gamma[nu_single, 0] += tf.reduce_sum(dirac_delta) / phonons.n_k_points
-            ps_and_gamma[nu_single, 1] += tf.reduce_sum(pot_times_dirac)
-        ps_and_gamma[nu_single, 1:] /= omega.flatten()[nu_single]
-        ps_and_gamma[nu_single, 1:] *= np.pi * phonons.hbar / 4 / n_k_points * gamma_to_thz
     return ps_and_gamma
 
 
 def calculate_dirac_delta_crystal(omega, population, physical_mode, sigma_tf, broadening_shape,
                                   index_kpp_full, index_k, mu, is_plus, is_balanced, default_delta_threshold=2):
+    """
+    Calculate the Dirac delta function for crystalline materials.
+
+    Args:
+        (various): Parameters describing the phonon properties and material
+
+    Returns:
+        tuple: Dirac delta function and related indices
+    """
     if not physical_mode[index_k, mu]:
         return None
     if broadening_shape == 'gauss':
@@ -223,11 +291,10 @@ def calculate_dirac_delta_crystal(omega, population, physical_mode, sigma_tf, br
     elif broadening_shape == 'lorentz':
         broadening_function = lorentz_delta
     else:
-        raise ('Broadening function not implemented')
+        raise ValueError('Broadening function not implemented')
     second_sign = (int(is_plus) * 2 - 1)
     omegas_difference = tf.abs(omega[index_k, mu] + second_sign * omega[:, :, tf.newaxis] -
                                tf.gather(omega, index_kpp_full)[:, tf.newaxis, :])
-
 
     condition = (omegas_difference < default_delta_threshold * 2 * np.pi * sigma_tf) & \
                 (physical_mode[:, :, np.newaxis]) & \
@@ -248,17 +315,21 @@ def calculate_dirac_delta_crystal(omega, population, physical_mode, sigma_tf, br
             if is_balanced:
                 # Detail balance
                 # (n0) * (n1) * (n2 + 2) - (n0 + 1) * (n1 + 1) * (n2) = 0
-                dirac_delta_tf = 0.5 * (tf.gather_nd(population, coords_1) + 1) * (tf.gather_nd(population, coords_2)) / (population[index_k, mu])
-                dirac_delta_tf += 0.5 * (tf.gather_nd(population, coords_1)) * (tf.gather_nd(population, coords_2) + 1) / (1 + population[index_k, mu])
+                dirac_delta_tf = 0.5 * (tf.gather_nd(population, coords_1) + 1) * (
+                    tf.gather_nd(population, coords_2)) / (population[index_k, mu])
+                dirac_delta_tf += 0.5 * (tf.gather_nd(population, coords_1)) * (
+                        tf.gather_nd(population, coords_2) + 1) / (1 + population[index_k, mu])
         else:
             dirac_delta_tf = 0.5 * (1 + tf.gather_nd(population, coords_1) + tf.gather_nd(population, coords_2))
             if is_balanced:
                 # Detail balance
                 # (n0) * (n1 + 1) * (n2 + 2) - (n0 + 1) * (n1) * (n2) = 0
-                dirac_delta_tf = 0.25 * (tf.gather_nd(population, coords_1)) * (tf.gather_nd(population, coords_2)) / (population[index_k, mu])
-                dirac_delta_tf += 0.25 * (tf.gather_nd(population, coords_1) + 1) * (tf.gather_nd(population, coords_2) + 1) / (1 + population[index_k, mu])
+                dirac_delta_tf = 0.25 * (tf.gather_nd(population, coords_1)) * (tf.gather_nd(population, coords_2)) / (
+                    population[index_k, mu])
+                dirac_delta_tf += 0.25 * (tf.gather_nd(population, coords_1) + 1) * (
+                        tf.gather_nd(population, coords_2) + 1) / (1 + population[index_k, mu])
         omegas_difference_tf = (omega[index_k, mu] + second_sign * tf.gather_nd(omega, coords_1) - tf.gather_nd(
-                omega, coords_2))
+            omega, coords_2))
 
         dirac_delta_tf = dirac_delta_tf * broadening_function(omegas_difference_tf, 2 * np.pi * sigma_tf)
 
@@ -269,7 +340,17 @@ def calculate_dirac_delta_crystal(omega, population, physical_mode, sigma_tf, br
         return tf.cast(dirac_delta_tf, dtype=tf.float64), index_kp, mup, index_kpp, mupp
 
 
-def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, broadening_shape, mu, is_balanced, default_delta_threshold=2):
+def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, broadening_shape, mu, is_balanced,
+                                    default_delta_threshold=2):
+    """
+    Calculate the Dirac delta function for amorphous materials.
+
+    Args:
+        (various): Parameters describing the phonon properties and material
+
+    Returns:
+        tuple: Dirac delta function and related indices
+    """
     if not physical_mode[0, mu]:
         return None
     if broadening_shape == 'triangle':
@@ -281,8 +362,8 @@ def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, 
         omegas_difference = np.abs(omega[0, mu] + second_sign * omega[0, :, np.newaxis] -
                                    omega[0, np.newaxis, :])
         condition = (omegas_difference < delta_threshold * 2 * np.pi * sigma_tf) & \
-                (physical_mode[0, :, np.newaxis]) & \
-                (physical_mode[0, np.newaxis, :])
+                    (physical_mode[0, :, np.newaxis]) & \
+                    (physical_mode[0, np.newaxis, :])
         interactions = tf.where(condition)
         if interactions.shape[0] > 0:
             # Create sparse index
@@ -296,7 +377,7 @@ def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, 
                     dirac_delta_tf = 0.5 * (tf.gather(population[0], mup_vec) + 1) * (
                         tf.gather(population[0], mupp_vec)) / (population[0, mu])
                     dirac_delta_tf += 0.5 * (tf.gather(population[0], mup_vec)) * (
-                                tf.gather(population[0], mupp_vec) + 1) / (1 + population[0, mu])
+                            tf.gather(population[0], mupp_vec) + 1) / (1 + population[0, mu])
             else:
                 dirac_delta_tf = 0.5 * (1 + tf.gather(population[0], mup_vec) + tf.gather(population[0], mupp_vec))
                 if is_balanced:
@@ -316,9 +397,9 @@ def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, 
             elif broadening_shape == 'lorentz':
                 broadening_function = lorentz_delta
             else:
-                raise('Broadening function not implemented')
+                raise ValueError('Broadening function not implemented')
 
-            dirac_delta_tf = dirac_delta_tf * broadening_function(omegas_difference_tf,  2 * np.pi * sigma_tf)
+            dirac_delta_tf = dirac_delta_tf * broadening_function(omegas_difference_tf, 2 * np.pi * sigma_tf)
 
             try:
                 mup = tf.concat([mup, mup_vec], 0)
@@ -334,10 +415,21 @@ def calculate_dirac_delta_amorphous(omega, population, physical_mode, sigma_tf, 
         return None
 
 
-def calculate_broadening(velocity_tf, cellinv, k_size, index_kpp_vec):
-    velocity_difference = velocity_tf[:, :, tf.newaxis, :] - tf.gather(velocity_tf, index_kpp_vec)[:,tf.newaxis, :, :]
-    # we want the last index of velocity (the coordinate index to dot from the right to rlattice vec
-    delta_k = cellinv / k_size
+def calculate_broadening(velocity_tf, cell_inv, k_size, index_kpp_vec):
+    """
+    Calculate the broadening for the Dirac delta function.
+
+    Args:
+        velocity_tf (tf.Tensor): Velocity tensor
+        cell_inv (tf.Tensor): Inverse of the unit cell
+        k_size (int): Size of the k-point mesh
+        index_kpp_vec (tf.Tensor): Indices of the k-points
+
+    Returns:
+        tf.Tensor: Calculated broadening
+    """
+    velocity_difference = velocity_tf[:, :, tf.newaxis, :] - tf.gather(velocity_tf, index_kpp_vec)[:, tf.newaxis, :, :]
+    delta_k = cell_inv / k_size
     base_sigma = tf.reduce_sum((tf.tensordot(velocity_difference, delta_k, [-1, 1])) ** 2, axis=-1)
     base_sigma = tf.sqrt(base_sigma / 6.)
     return base_sigma

--- a/kaldo/tests/test_lazy_loading.py
+++ b/kaldo/tests/test_lazy_loading.py
@@ -1,0 +1,320 @@
+import pytest
+import numpy as np
+import os
+import h5py
+from unittest.mock import MagicMock
+
+from kaldo.helpers.storage import (
+    load,
+    save,
+    get_folder_from_label,
+    lazy_property,
+    is_calculated,
+    LAZY_PREFIX,
+    DEFAULT_STORE_FORMATS,
+)
+
+
+def test_load_memory_format_property_not_found():
+    property = 'test_property'
+
+    class Instance(object):
+        pass
+
+    instance = Instance()
+    folder = 'test_folder'
+    format = 'memory'
+
+    with pytest.raises(KeyError):
+        load(property, folder, instance, format=format)
+
+
+def test_save_hdf5_format(monkeypatch):
+    class MockStorage(dict):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def create_dataset(self, name, data, chunks, compression, compression_opts):
+            self[name] = data
+
+    storage_instance = MockStorage()
+
+    def mock_h5py_File(filename, mode):
+        assert filename == 'test_folder.hdf5'
+        assert mode == 'a'
+        return storage_instance
+
+    monkeypatch.setattr(h5py, 'File', mock_h5py_File)
+    property = 'test_property'
+    folder = 'test_folder'
+    loaded_attr = np.array([4, 5, 6])
+    format = 'hdf5'
+
+    save(property, folder, loaded_attr, format=format)
+
+    # Verify that the dataset was created
+    assert 'test_folder/test_property' in storage_instance
+    np.testing.assert_array_equal(storage_instance['test_folder/test_property'], loaded_attr)
+
+
+def test_get_folder_from_label():
+    class Instance(object):
+        folder = 'base_folder'
+        kpts = [2, 2, 2]
+
+    instance = Instance()
+    folder = get_folder_from_label(instance)
+    assert folder == 'base_folder/2_2_2'
+
+
+def test_load_formatted_mean_free_path(monkeypatch):
+    def mock_loadtxt(filename, skiprows=1):
+        if filename == 'test_folder/mean_free_path_0.dat':
+            return np.array([[1, 2], [3, 4]])
+        elif filename == 'test_folder/mean_free_path_1.dat':
+            return np.array([[5, 6], [7, 8]])
+        elif filename == 'test_folder/mean_free_path_2.dat':
+            return np.array([[9, 10], [11, 12]])
+        else:
+            raise FileNotFoundError
+
+    monkeypatch.setattr(np, 'loadtxt', mock_loadtxt)
+    property = 'mean_free_path'
+    folder = 'test_folder'
+    instance = MagicMock()
+    format = 'formatted'
+    result = load(property, folder, instance, format=format)
+    expected_loaded = [
+        np.array([[1, 2], [3, 4]]),
+        np.array([[5, 6], [7, 8]]),
+        np.array([[9, 10], [11, 12]]),
+    ]
+    expected_result = np.array(expected_loaded).transpose(1, 2, 0)
+    np.testing.assert_array_equal(result, expected_result)
+
+
+def test_load_formatted_conductivity(monkeypatch):
+    def mock_loadtxt(filename, skiprows=1):
+        mapping = {
+            'test_folder/conductivity_0_0.dat': np.array([1, 2]),
+            'test_folder/conductivity_0_1.dat': np.array([3, 4]),
+            'test_folder/conductivity_0_2.dat': np.array([5, 6]),
+            'test_folder/conductivity_1_0.dat': np.array([7, 8]),
+            'test_folder/conductivity_1_1.dat': np.array([9, 10]),
+            'test_folder/conductivity_1_2.dat': np.array([11, 12]),
+            'test_folder/conductivity_2_0.dat': np.array([13, 14]),
+            'test_folder/conductivity_2_1.dat': np.array([15, 16]),
+            'test_folder/conductivity_2_2.dat': np.array([17, 18]),
+        }
+        return mapping[filename]
+
+    monkeypatch.setattr(np, 'loadtxt', mock_loadtxt)
+    property = 'conductivity'
+    folder = 'test_folder'
+    instance = MagicMock()
+    instance.n_phonons = 2
+    format = 'formatted'
+    result = load(property, folder, instance, format=format)
+    expected_result = np.array([
+        [[1, 3, 5], [7, 9, 11], [13, 15, 17]],
+        [[2, 4, 6], [8, 10, 12], [14, 16, 18]],
+    ])
+    np.testing.assert_array_equal(result, expected_result)
+
+
+def test_load_formatted_sij_property(monkeypatch):
+    def mock_loadtxt(filename, skiprows=1, dtype=complex):
+        if filename == 'test_folder/test_sij_0.dat':
+            return np.array([1 + 1j, 2 + 2j])
+        elif filename == 'test_folder/test_sij_1.dat':
+            return np.array([3 + 3j, 4 + 4j])
+        elif filename == 'test_folder/test_sij_2.dat':
+            return np.array([5 + 5j, 6 + 6j])
+        else:
+            raise FileNotFoundError
+
+    monkeypatch.setattr(np, 'loadtxt', mock_loadtxt)
+    property = 'test_sij'
+    folder = 'test_folder'
+    instance = MagicMock()
+    format = 'formatted'
+    result = load(property, folder, instance, format=format)
+    expected_result = np.array([
+        [1 + 1j, 3 + 3j, 5 + 5j],
+        [2 + 2j, 4 + 4j, 6 + 6j],
+    ])
+    np.testing.assert_array_equal(result, expected_result)
+
+
+def test_load_missing_file(monkeypatch):
+    def mock_loadtxt(filename, skiprows=1, dtype=float):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(np, 'loadtxt', mock_loadtxt)
+    property = 'nonexistent_property'
+    folder = 'test_folder'
+    instance = MagicMock()
+    format = 'formatted'
+    with pytest.raises(FileNotFoundError):
+        load(property, folder, instance, format=format)
+
+
+def test_save_formatted_sij_property(monkeypatch):
+    def mock_exists(path):
+        return False
+
+    monkeypatch.setattr(os.path, 'exists', mock_exists)
+
+    def mock_makedirs(path):
+        pass
+
+    monkeypatch.setattr(os, 'makedirs', mock_makedirs)
+    saved_files = {}
+
+    def mock_savetxt(filename, data, fmt, header):
+        saved_files[filename] = (data, fmt, header)
+
+    monkeypatch.setattr(np, 'savetxt', mock_savetxt)
+    property = 'test_sij'
+    folder = 'test_folder'
+    loaded_attr = np.array([
+        [1 + 1j, 2 + 2j, 3 + 3j],
+        [4 + 4j, 5 + 5j, 6 + 6j],
+    ])
+    format = 'formatted'
+    save(property, folder, loaded_attr, format=format)
+    for alpha in range(3):
+        filename = f'test_folder/test_sij_{alpha}.dat'
+        data, fmt, header = saved_files[filename]
+        expected_data = loaded_attr[..., alpha].flatten()
+        np.testing.assert_array_equal(data, expected_data)
+        assert fmt == '%.18e'
+
+
+def test_get_folder_from_label_with_temperature():
+    class Instance(object):
+        folder = 'base_folder'
+        kpts = [2, 2, 2]
+        temperature = 300
+        is_classic = False
+
+    label = '<temperature>/<statistics>'
+    instance = Instance()
+    folder = get_folder_from_label(instance, label)
+    assert folder == 'base_folder/2_2_2/300/quantum'
+
+
+def test_get_folder_from_label_with_method_and_length():
+    class Instance(object):
+        folder = 'base_folder'
+        kpts = [3, 3, 3]
+        method = 'rta'
+        length = [10, None, 0]
+        finite_length_method = 'some_method'
+
+    label = '<method>/<length>/<finite_length_method>'
+    instance = Instance()
+    folder = get_folder_from_label(instance, label)
+    assert folder == 'base_folder/3_3_3/rta/l_10_0_0/fssome_method'
+
+
+def test_lazy_property_with_storage_formats(monkeypatch):
+    # Mock the load and save functions
+    def mock_load(property, folder, instance, format):
+        return 'loaded_value'
+
+    def mock_save(property, folder, loaded_attr, format):
+        pass
+
+    monkeypatch.setattr('kaldo.helpers.storage.load', mock_load)
+    monkeypatch.setattr('kaldo.helpers.storage.save', mock_save)
+    # Add 'test_attr' to DEFAULT_STORE_FORMATS for the test
+    DEFAULT_STORE_FORMATS['test_attr'] = 'formatted'
+
+    class TestClass:
+        def __init__(self, storage):
+            self.storage = storage
+            self.folder = 'test_folder'
+            self.kpts = [2, 2, 2]
+
+        @lazy_property()
+        def test_attr(self):
+            return 'computed_value'
+
+    try:
+        # Test with 'memory' storage
+        instance_memory = TestClass('memory')
+        assert instance_memory.test_attr == 'computed_value'
+        # Test with 'numpy' storage
+        instance_numpy = TestClass('numpy')
+        assert instance_numpy.test_attr == 'loaded_value'
+        # Test with 'formatted' storage
+        instance_formatted = TestClass('formatted')
+        assert instance_formatted.test_attr == 'loaded_value'
+    finally:
+        # Clean up DEFAULT_STORE_FORMATS
+        del DEFAULT_STORE_FORMATS['test_attr']
+
+
+def test_is_calculated_true():
+    class Instance(object):
+        pass
+
+    instance = Instance()
+    setattr(instance, LAZY_PREFIX + 'test_property', 'value')
+    result = is_calculated('test_property', instance)
+    assert result == True
+
+
+def test_is_calculated_false(monkeypatch):
+    class Instance(object):
+        folder = 'test_folder'
+
+    instance = Instance()
+
+    def mock_load(property, folder, instance, format):
+        raise FileNotFoundError
+
+    monkeypatch.setattr('kaldo.helpers.storage.load', mock_load)
+
+    result = is_calculated('test_property', instance)
+    assert result == False
+
+
+def test_is_calculated_with_stored_property(monkeypatch):
+    class Instance(object):
+        folder = 'test_folder'
+        storage = 'formatted'
+        kpts = [2, 2, 2]
+
+    instance = Instance()
+
+    # Mock load to return a value
+    def mock_load(property, folder, instance, format):
+        return 'stored_value'
+
+    monkeypatch.setattr('kaldo.helpers.storage.load', mock_load)
+    result = is_calculated('test_property', instance)
+    assert result == True
+    # Ensure the property is set on the instance
+    attr = LAZY_PREFIX + 'test_property'
+    assert getattr(instance, attr) == 'stored_value'
+
+
+def test_is_calculated_property_not_available(monkeypatch):
+    class Instance(object):
+        folder = 'test_folder'
+        storage = 'formatted'
+        kpts = [2, 2, 2]
+
+    instance = Instance()
+
+    def mock_load(property, folder, instance, format):
+        raise FileNotFoundError
+
+    monkeypatch.setattr('kaldo.helpers.storage.load', mock_load)
+    result = is_calculated('test_property', instance)
+    assert result == False


### PR DESCRIPTION
14 Squashed commits:
[c680c4a] Revert changes on `storage.py`
[5720c70] Split third order calculation to run on a single nu (phonon index) at the time. 
[290b1b8] Change order of parameters in single nu calculations 
[c196ff0] Add documentation
[0b70086] Fix error in parameters names
[d255d0f] Code cleanup
[7b6e7cc] fix typo
[7305077] Minor fix
[8ce725f] Reverted units update
[783c270] Add single mu for amorphous
[53cf056] Refactor single mu method for crystal
[15f2ba7] Update storage helper
[8687eaa] Clean up decorator for lazy loading.