### PR TITLE
Parallelize pytest to reduce CI time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: python -m pytest -v --cov=kaldo --cov-report=xml --color=yes kaldo/tests/
+          command: python -m pytest -n auto -v --cov=kaldo --cov-report=xml --color=yes kaldo/tests/
           name: Test
       - codecov/upload:
           file: ./coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN conda install pip \
     && pip install -r /app/requirements.txt \
     && pip install pytest \
     && pip install pytest-cov \
+    && pip install 'pytest-xdist[psutil]' \
     && pip install -r requirements.txt
     
 CMD ["/bin/bash"]


### PR DESCRIPTION
I tested in my local environment that `pytest-xdis` library can distribute tasks across multiple cores if available. It worth to try this to reduce CI time.  