### PR TITLE
Fix network issue when download_isotope_data in a better way

### DIFF
--- a/kaldo/controllers/isotopic.py
+++ b/kaldo/controllers/isotopic.py
@@ -10,6 +10,8 @@ from kaldo.helpers.logger import get_logger, log_size
 from kaldo.controllers.dirac_kernel import gaussian_delta, triangular_delta, lorentz_delta
 from ase.data.isotopes import download_isotope_data
 import json
+from importlib import resources as impresources
+import kaldo.controllers
 logging = get_logger()
 
 
@@ -122,7 +124,8 @@ def compute_gfactor(list_of_atomic_numbers):
     except:
         ## Legacy gfactor database. The isotopic database was downloaded with ase.data.isotopes on 20/03/2024.
         # unstable elements have None as gfactor. Mostly elements with Z>92
-        with open('./legacy_dataset.json', 'r') as file:
+        dataset_file = impresources.files(kaldo.controllers) / 'legacy_dataset.json'
+        with dataset_file.open('r') as file:
             g_factor_dict = json.load(file)
         logging.info('online isotopic data not available, using legacy data.')
         for element in minimal_list:


### PR DESCRIPTION
I fixed this bug by locating the path to the library and find the json file. 

This fixes requires python verison >= 3.9. 