### PR TITLE
Citation sync june 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ operations on tensors, to take advantage of multithreading on GPU and CPU using 
 | [2]                   | fundamental theory and implementations on Quasi-Harmonic Green Kubo (QHGK) |
 | [3]                   | participation ratio               |
 | [4]                   | finite size thermal conductivity calculations with ALD-BTE|
-| [5]                   | PIMD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations|
+| [5]                   | path-integral MD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations|
+| [6]                   | isotopic scattering based on Tamura formula hydrodynamic extrapolation
 
 ## References
 
@@ -48,6 +49,9 @@ operations on tensors, to take advantage of multithreading on GPU and CPU using 
 [Ultrahigh convergent thermal conductivity of carbon nanotubes from comprehensive atomistic modeling](https://doi.org/10.1103/PhysRevLett.127.025902), Phys. Rev. Lett. **127**, 025902 (2021).
 
 [5] Dylan A. Folkner, Zekun Chen, Giuseppe Barbalinardo, Florian Knoop, Davide Donadio, [Elastic moduli and thermal conductivity of quantum materials at finite temperature](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173), J. Appl. Phys. **136**,  221101 (2024).
+
+[6] Alfredo Fiorentino,  Paolo Pegolo,  Stefano Baroni,  Davide Donadio, [Effects of colored disorder on the heat conductivity of SiGe alloys from first principles](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205), Phys. Rev. B. ***111***, 134205 (2025).
+
 
 ## Publications using kALDo
 

--- a/docs/docsource/citations.md
+++ b/docs/docsource/citations.md
@@ -7,7 +7,7 @@
 | [3]                   | participation ratio               |
 | [4]                   | finite size thermal conductivity calculations with ALD-BTE|
 | [5]                   | path-integral MD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations|
-| [6]                   | isotopic scattering based on Tamura formula hydrodynamic extrapolation
+| [6]                   | isotopic scattering based on Tamura formula and hydrodynamic extrapolation
 
 ## References
 

--- a/docs/docsource/citations.md
+++ b/docs/docsource/citations.md
@@ -1,19 +1,25 @@
-### How to cite
+## Citations
 
-If you have used kALDo, please cite the following article:
+| Reference             | Cite for what?                    |
+| --------------------- | --------------------------------- |
+| [1]                   | for any work that used `kALDo`    |
+| [2]                   | fundamental theory and implementations on Quasi-Harmonic Green Kubo (QHGK) |
+| [3]                   | participation ratio               |
+| [4]                   | finite size thermal conductivity calculations with ALD-BTE|
+| [5]                   | path-integral MD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations|
+| [6]                   | isotopic scattering based on Tamura formula hydrodynamic extrapolation
 
-Barbalinardo, G.; Chen, Z.; Lundgren, N. W.; Donadio, D. Efficient Anharmonic Lattice Dynamics Calculations of Thermal Transport in Crystalline and Disordered Solids. J Appl Phys 2020, 128 (13), 135104–135112. https://doi.org/10.1063/5.0020443
-also available open access on ArXiv: https://arxiv.org/abs/2009.01967
+## References
 
-```
-@article{kaldo,
-author = {Barbalinardo, Giuseppe and Chen, Zekun and Lundgren, Nicholas W and Donadio, Davide},
-title = {{Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids}},
-journal = {Journal of Applied Physics},
-year = {2020},
-volume = {128},
-number = {13},
-pages = {135104--12},
-month = oct
-}
-```
+[1] Giuseppe Barbalinardo, Zekun Chen, Nicholas W. Lundgren, Davide Donadio, [Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids](https://aip.scitation.org/doi/10.1063/5.0020443), J. Appl. Phys. **128**, 135104 (2020).
+
+[2] L Isaeva, G Barbalinardo, D Donadio, S Baroni, [Modeling heat transport in crystals and glasses from a unified lattice-dynamical approach](https://www.nature.com/articles/s41467-019-11572-4), Nat. Commun ***10***: 3853 (2019)
+
+[3] Nicholas W. Lundgren, Giuseppe Barbalinardo, Davide Donadio, [Mode Localization and Suppressed Heat Transport in Amorphous Alloys](https://doi.org/10.1103/PhysRevB.103.024204), Phys. Rev. B **103**, 024204 (2021).
+
+[4] Giuseppe Barbalinardo, Zekun Chen, Haikuan Dong, Zheyong Fan, Davide Donadio,
+[Ultrahigh convergent thermal conductivity of carbon nanotubes from comprehensive atomistic modeling](https://doi.org/10.1103/PhysRevLett.127.025902), Phys. Rev. Lett. **127**, 025902 (2021).
+
+[5] Dylan A. Folkner, Zekun Chen, Giuseppe Barbalinardo, Florian Knoop, Davide Donadio, [Elastic moduli and thermal conductivity of quantum materials at finite temperature](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173), J. Appl. Phys. **136**,  221101 (2024).
+
+[6] Alfredo Fiorentino,  Paolo Pegolo,  Stefano Baroni,  Davide Donadio, [Effects of colored disorder on the heat conductivity of SiGe alloys from first principles](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205), Phys. Rev. B. ***111***, 134205 (2025).

--- a/docs/publications/readme.md
+++ b/docs/publications/readme.md
@@ -19,7 +19,9 @@
 * G Romano,
 [Openbte: a solver for ab-initio phonon transport in multidimensional structures](https://arxiv.org/abs/2106.02764).
 
-## 2025 (10)
+## 2025 (11)
+
+* Xiongfei Zhu,  Jianshi Sun, Yucheng Xiong,  Shouhang Li,  Xiangjun Liu, [Research on thermal transport mechanism of amorphous hafnia based on quasi-harmonic Green-Kubo theory combined with hydrodynamic extrapolation method](https://www.cpsjournals.cn/article/doi/10.7498/aps.74.20250350), Acta. Phys. Sin. ***74(11)***, 116302-1 (2025).
 
 * Alfredo Fiorentino,  Paolo Pegolo,  Stefano Baroni,  Davide Donadio, [Effects of colored disorder on the heat conductivity of SiGe alloys from first principles](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205), Phys. Rev. B. ***111***, 134205 (2025).
 


### PR DESCRIPTION
This PR aims to accomplish the following goals:

1). Sync citations as of June 27th 2025.
2). Add paper https://github.com/nanotheorygroup/kaldo/pull/6 (Alfredo and Davide's recent publication on SiGe alloys) to "cite for what".
3). Sync format of how users cite us from README.md to documentation page.