### PR TITLE
Fix io for newer format of 2nd IFCs from vasp.

### DIFF
--- a/kaldo/interfaces/shengbte_io.py
+++ b/kaldo/interfaces/shengbte_io.py
@@ -42,7 +42,7 @@ def read_second_order_matrix(filename, supercell):
     """
     with open(filename, 'r') as file:
         first_row = file.readline()
-        n_rows = np.unique(np.asarray(first_row, dtype=int))
+        n_rows = int(first_row.strip().split()[0])
         n_replicas = np.prod(supercell)
         n_unit_atoms = int(n_rows / n_replicas)
 


### PR DESCRIPTION
This PR addresses the io for vasp 2nd order IFCs with newer format. Where number of atoms in the supercell are written twice in the first line instead of once. Current fix ensures both old and new format can be imported.



