### PR TITLE
Fix temperature-dependent storage paths in HarmonicWithQTemp

### DIFF
--- a/kaldo/observables/harmonic_with_q_temp.py
+++ b/kaldo/observables/harmonic_with_q_temp.py
@@ -23,6 +23,13 @@ class HarmonicWithQTemp(hwq.HarmonicWithQ):
         if self.is_classic:
             self.hbar = self.hbar * 1e-6
 
+    def _get_folder_path_components(self, label):
+        components = []
+        if '<temperature>' in label:
+            components.append(str(int(self.temperature)))
+        if '<statistics>' in label:
+            components.append('classic' if self.is_classic else 'quantum')
+        return components
 
     @lazy_property(label='<temperature>/<statistics>/<q_point>')
     def population(self):


### PR DESCRIPTION
Add _get_folder_path_components() to properly parse <temperature> and <statistics> placeholders in property labels. Without this, temperature- dependent properties (heat_capacity_2d, population, heat_capacity) were cached to paths missing temperature/statistics components, causing data from one temperature to be incorrectly reused for subsequent temperatures in QHGK conductivity calculations.