### PR TITLE
`k`-points parallelization

### DIFF
--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -4,7 +4,9 @@ import os
 import numpy as np
 from concurrent.futures import as_completed
 from kaldo.helpers.logger import get_logger
-from kaldo.parallel import get_executor, is_parallel, validate_parallel_calculator
+from kaldo.parallel import (
+    dispatch_with_resume, get_executor, is_parallel, validate_parallel_calculator,
+)
 from sparse import COO
 logging = get_logger()
 
@@ -54,39 +56,27 @@ def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=Fal
     n_atoms = n_unit_cell_atoms
     n_replicas = int(n_replicated_atoms / n_unit_cell_atoms)
     use_scratch = scratch_dir is not None
-    if use_scratch:
-        os.makedirs(scratch_dir, exist_ok=True)
-        atoms_to_compute = [
-            atom_id for atom_id in range(n_atoms)
-            if not os.path.exists(os.path.join(scratch_dir, f'iat_{atom_id:05d}.done'))
-        ]
-        n_resumed = n_atoms - len(atoms_to_compute)
-        if n_resumed:
-            logging.info(f'Resuming: skipping {n_resumed} already-computed atom(s)')
-    else:
+    if not use_scratch:
         second = np.zeros((n_atoms, 3, n_replicated_atoms * 3))
-        atoms_to_compute = list(range(n_atoms))
-    use_parallel = n_workers is None or n_workers > 1
-    backend = 'process' if use_parallel else 'serial'
-    executor_workers = n_workers if use_parallel else None
 
     worker_fn = functools.partial(
         _compute_iat_second,
+        replicated_atoms=replicated_atoms,
+        second_order_delta=second_order_delta,
         calculator=calculator,
         scratch_dir=scratch_dir,
     )
 
-    with get_executor(backend=backend, n_workers=executor_workers) as executor:
-        futures = {
-            executor.submit(worker_fn, i, replicated_atoms, second_order_delta): i
-            for i in atoms_to_compute
-        }
-        for future in as_completed(futures):
-            atom_id, second_per_atom = future.result()
-            if is_verbose:
-                logging.info('calculating forces on atom ' + str(atom_id))
-            if not use_scratch:
-                second[atom_id] = second_per_atom
+    for atom_id, result in dispatch_with_resume(
+        range(n_atoms), worker_fn,
+        n_workers=n_workers,
+        output_dir=scratch_dir,
+        sentinel_prefix="iat_",
+        log_progress=is_verbose,
+    ):
+        if not use_scratch:
+            _, second_per_atom = result
+            second[atom_id] = second_per_atom
 
     if use_scratch:
         second = _assemble_from_scratch_second(scratch_dir, n_atoms, n_replicated_atoms, keep_scratch)
@@ -117,8 +107,8 @@ def _compute_iat_second(atom_id, replicated_atoms, second_order_delta, calculato
             second_per_atom[alpha, :] += move * calculate_gradient(replicated_atoms.positions + shift,
                                                                    replicated_atoms)
     if scratch_dir is not None:
+        # Sentinel is written by dispatch_with_resume after this returns.
         np.save(os.path.join(scratch_dir, f'iat_{atom_id:05d}.npy'), second_per_atom)
-        open(os.path.join(scratch_dir, f'iat_{atom_id:05d}.done'), 'w').close()
         return atom_id, None
     return atom_id, second_per_atom
 
@@ -205,9 +195,7 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     n_atoms = len(atoms.numbers)
     n_replicas = int(replicated_atoms.positions.shape[0] / n_atoms)
     use_scratch = scratch_dir is not None
-    if use_scratch:
-        os.makedirs(scratch_dir, exist_ok=True)
-    else:
+    if not use_scratch:
         i_at_sparse = []
         i_coord_sparse = []
         jat_sparse = []
@@ -218,53 +206,37 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     n_forces_done = 0
     n_forces_skipped = 0
 
-    use_parallel = n_workers is None or n_workers > 1
-
-    # Determine which atoms need computing (resume support via scratch sentinels)
-    if use_scratch:
-        atoms_to_compute = [iat for iat in range(n_atoms)
-                             if not os.path.exists(os.path.join(scratch_dir, f'iat_{iat:05d}.done'))]
-        n_resumed = n_atoms - len(atoms_to_compute)
-        if n_resumed:
-            logging.info(f'Resuming: skipping {n_resumed} already-computed atom(s)')
-    else:
-        atoms_to_compute = list(range(n_atoms))
-
-    # Select backend: 'process' for parallel, 'serial' for single-threaded
-    backend = 'process' if use_parallel else 'serial'
-    executor_workers = n_workers if use_parallel else None
-
     worker_fn = functools.partial(
         _compute_iat_third,
+        atoms=atoms,
+        replicated_atoms=replicated_atoms,
+        third_order_delta=third_order_delta,
+        distance_threshold=distance_threshold,
+        is_verbose=is_verbose,
         calculator=calculator,
         scratch_dir=scratch_dir,
         jat_flush_every=jat_flush_every,
     )
 
-    with get_executor(backend=backend, n_workers=executor_workers) as executor:
-        futures = {
-            executor.submit(worker_fn, iat, atoms, replicated_atoms,
-                           third_order_delta, distance_threshold, is_verbose): iat
-            for iat in atoms_to_compute
-        }
-        for future in as_completed(futures):
-            iat = futures[future]
-            local_i_at, local_i_coord, local_jat, local_j_coord, local_k, local_value, n_done, n_skipped = future.result()
-            if not use_scratch:
-                i_at_sparse.extend(local_i_at)
-                i_coord_sparse.extend(local_i_coord)
-                jat_sparse.extend(local_jat)
-                j_coord_sparse.extend(local_j_coord)
-                k_sparse.extend(local_k)
-                value_sparse.extend(local_value)
-            n_forces_done += n_done
-            n_forces_skipped += n_skipped
-            if use_parallel:
-                logging.info(f'Completed atom {iat}: '
-                             f'{int((n_forces_done + n_forces_skipped) / n_forces_to_calculate * 100)}% done')
-            elif (n_forces_done + n_forces_skipped) % 300 == 0:
-                logging.info('Calculate third derivatives ' + str(
-                    int((n_forces_done + n_forces_skipped) / n_forces_to_calculate * 100)) + '%')
+    for iat, result in dispatch_with_resume(
+        range(n_atoms), worker_fn,
+        n_workers=n_workers,
+        output_dir=scratch_dir,
+        sentinel_prefix="iat_",
+        log_progress=False,
+    ):
+        local_i_at, local_i_coord, local_jat, local_j_coord, local_k, local_value, n_done, n_skipped = result
+        if not use_scratch:
+            i_at_sparse.extend(local_i_at)
+            i_coord_sparse.extend(local_i_coord)
+            jat_sparse.extend(local_jat)
+            j_coord_sparse.extend(local_j_coord)
+            k_sparse.extend(local_k)
+            value_sparse.extend(local_value)
+        n_forces_done += n_done
+        n_forces_skipped += n_skipped
+        logging.info(f'Completed atom {iat}: '
+                     f'{int((n_forces_done + n_forces_skipped) / n_forces_to_calculate * 100)}% done')
     logging.info('total forces to calculate third : ' + str(n_forces_to_calculate))
     logging.info('forces calculated : ' + str(n_forces_done))
     logging.info('forces skipped (outside distance threshold) : ' + str(n_forces_skipped))
@@ -347,7 +319,7 @@ def _compute_iat_third(iat, atoms, replicated_atoms, third_order_delta, distance
     if use_scratch:
         if chunk_values:
             _flush_chunk_third(scratch_dir, iat, chunk_id, chunk_coords, chunk_values)
-        open(os.path.join(scratch_dir, f'iat_{iat:05d}.done'), 'w').close()
+        # Sentinel is written by dispatch_with_resume after this returns.
         return [], [], [], [], [], [], n_done, n_skipped
 
     if not chunk_coords:

--- a/kaldo/parallel/__init__.py
+++ b/kaldo/parallel/__init__.py
@@ -18,10 +18,12 @@ import pickle
 import warnings
 
 from kaldo.parallel.executor import get_executor, SerialExecutor
+from kaldo.parallel.dispatcher import dispatch_with_resume
 
 __all__ = [
     'get_executor', 'SerialExecutor', 'is_parallel',
     'validate_parallel_calculator', 'maybe_warn_ml_delta_shift',
+    'dispatch_with_resume',
 ]
 
 

--- a/kaldo/parallel/dispatcher.py
+++ b/kaldo/parallel/dispatcher.py
@@ -1,0 +1,102 @@
+"""Dispatch with resume: the loop that's identical across kaldo's
+parallel-with-disk-checkpointing call sites.
+
+Why it exists: ``calculate_second``, ``calculate_third`` (FD), and
+``_project_crystal`` (k-point projection) all do the same thing:
+filter out units that already have a ``.done`` sentinel on disk,
+submit the rest to a process pool, and wait for them to complete.
+That loop was copy-pasted three times before this module existed.
+
+What it does NOT do: choose the on-disk file format, assemble results
+into the caller's output shape, or keep results in memory past the
+``yield``. Workers write their own data; the helper only writes the
+sentinel after the worker returns successfully (atomicity guarantee:
+no sentinel without a complete result).
+"""
+import os
+from concurrent.futures import as_completed
+
+from kaldo.helpers.logger import get_logger
+from kaldo.parallel.executor import get_executor
+
+logging = get_logger()
+
+
+def dispatch_with_resume(
+    work_ids,
+    worker_fn,
+    *,
+    n_workers,
+    output_dir=None,
+    sentinel_prefix="unit_",
+    log_progress=True,
+):
+    """Dispatch ``worker_fn(unit_id)`` across workers with optional resume.
+
+    Parameters
+    ----------
+    work_ids : iterable of int
+        All unit identifiers the caller would dispatch in a fresh run.
+        Integers only; used in ``f"{sentinel_prefix}{uid:05d}.done"``.
+    worker_fn : callable
+        Picklable callable taking a single ``unit_id`` argument and
+        returning the per-unit result. If ``output_dir`` is set, the worker
+        is responsible for writing its own output file under ``output_dir``
+        before returning.
+    n_workers : int or None
+        Forwarded to ``get_executor``. ``1`` runs the serial backend;
+        anything else picks the process backend.
+    output_dir : str or os.PathLike or None
+        Directory used both for resume detection (skipping any unit whose
+        ``<sentinel_prefix>NNNNN.done`` already exists) and as the
+        destination for the sentinel files. Created if missing.
+    sentinel_prefix : str
+        Prefix for the sentinel filename. Default ``"unit_"``.
+    log_progress : bool
+        When True, log one line per completed unit.
+
+    Yields
+    ------
+    (unit_id, result) tuples in completion order.
+    """
+    work_ids = list(work_ids)
+    n_total = len(work_ids)
+
+    if output_dir is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        pending = [
+            uid for uid in work_ids
+            if not os.path.exists(
+                os.path.join(output_dir, f"{sentinel_prefix}{uid:05d}.done")
+            )
+        ]
+        n_resumed = n_total - len(pending)
+        if n_resumed and log_progress:
+            logging.info(
+                f"Resuming: skipping {n_resumed} already-computed unit(s)"
+            )
+    else:
+        pending = list(work_ids)
+
+    use_parallel = n_workers is None or n_workers > 1
+    backend = "process" if use_parallel else "serial"
+    executor_workers = n_workers if use_parallel else None
+
+    with get_executor(backend=backend, n_workers=executor_workers) as executor:
+        futures = {executor.submit(worker_fn, uid): uid for uid in pending}
+        for future in as_completed(futures):
+            uid = futures[future]
+            result = future.result()
+            if output_dir is not None:
+                # Sentinel only AFTER worker_fn returns. If a worker crashes
+                # mid-write its .done file is missing and the next run
+                # recomputes that unit — same contract the FD code had.
+                open(
+                    os.path.join(
+                        output_dir, f"{sentinel_prefix}{uid:05d}.done"
+                    ),
+                    "w",
+                ).close()
+            if log_progress:
+                logging.info(f"Completed unit {uid}")
+            yield uid, result

--- a/kaldo/parallel/executor.py
+++ b/kaldo/parallel/executor.py
@@ -6,25 +6,41 @@ so computation code is identical regardless of backend.
 
 import multiprocessing
 import os
+import sys
 import warnings
 from concurrent.futures import Future, ProcessPoolExecutor
 
 
 def _default_mp_context():
-    """Return a multiprocessing context safe for CUDA calculators.
+    """Return a multiprocessing context safe for TF and CUDA calculators.
 
-    Fork (Linux default) cannot be used once CUDA is initialized in the parent:
-    torch refuses to re-initialize CUDA in a forked child (BrokenProcessPool /
-    'Cannot re-initialize CUDA in forked subprocess'). Spawn avoids this at a
-    small cold-start cost per worker and is the default on macOS.
+    Fork (Linux default) is unsafe in two situations kaldo regularly hits:
 
-    We pick spawn whenever CUDA is *available*, not only when it has been
-    initialized. Torch lazy-loads CUDA: ``is_initialized()`` returns False
-    until a tensor or model touches the device. By the time the calculator
-    runs in a worker it will initialize CUDA, so anticipating that here is
-    the correct choice. The cold-start cost of spawn (~1s/worker) is
-    negligible next to a single force evaluation.
+    1. CUDA initialized in the parent: torch refuses to re-initialize CUDA
+       in a forked child (BrokenProcessPool /
+       'Cannot re-initialize CUDA in forked subprocess').
+    2. TensorFlow imported in the parent: TF eagerly creates a thread pool
+       and grpc/cuda runtime state at import time. Forking duplicates the
+       file descriptors but not the threads, leaving the child's runtime
+       in a half-initialized state. Symptoms range from silent deadlocks
+       (TF op blocks waiting for a worker thread that never existed in
+       this process) to ``CUDA_ERROR_INVALID_HANDLE`` when the child
+       inherits a stale GPU context. xdist + parallel kaldo on Linux
+       reliably tickles this — see PR #231 CI hang.
+
+    Spawn avoids both because the worker starts from a clean Python
+    interpreter and re-imports modules itself. Cold-start cost is ~0.5s
+    per worker, negligible compared to one phonon calculation.
+
+    We anticipate CUDA: ``torch.cuda.is_available()`` returns True even
+    before any tensor touches the device. By the time the calculator runs
+    in a worker it will initialize CUDA, so picking spawn up front is the
+    correct choice. Same logic for TF: if it's already imported, the
+    parent is tainted; even if it isn't, kaldo's own modules import TF on
+    demand inside ``Phonons``, so the worker will be tainted too.
     """
+    if 'tensorflow' in sys.modules:
+        return multiprocessing.get_context('spawn')
     try:
         import torch  # lazy: don't force-import torch for non-ML users
         if torch.cuda.is_available():

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -59,11 +59,6 @@ def _compute_kpoint_projection(index_k, n_modes, n_k_points, omega, physical_mod
     where each *_data_list is [is_plus_0, is_plus_1] with entries as
     (indices, values, dense_shape) numpy tuples or None.
     """
-    # Pin BLAS threads in worker processes
-    os.environ['OMP_NUM_THREADS'] = '1'
-    os.environ['MKL_NUM_THREADS'] = '1'
-    os.environ['OPENBLAS_NUM_THREADS'] = '1'
-
     # Reconstruct TF tensors from numpy
     evect_tf = tf.cast(tf.convert_to_tensor(evect_np), dtype=tf.complex128)
     second_minus = tf.math.conj(evect_tf)

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -3,6 +3,9 @@ kaldo
 Anharmonic Lattice Dynamics
 
 """
+import functools
+import os
+
 from kaldo.storable import is_calculated
 from kaldo.storable import lazy_property, Storable
 from kaldo.helpers.logger import log_size
@@ -14,6 +17,8 @@ from kaldo.forceconstants import ForceConstants
 import kaldo.controllers.anharmonic as aha
 import tensorflow as tf
 import kaldo.controllers.isotopic as isotopic
+from concurrent.futures import as_completed
+from kaldo.parallel import dispatch_with_resume, get_executor
 from scipy import stats
 import numpy as np
 from numpy.typing import ArrayLike
@@ -26,6 +31,145 @@ logging = get_logger()
 # Constants
 GAMMA_TO_THZ = 1e11 * units.mol * (units.mol / (10 * units.J)) ** 2
 THZ_TO_MEV = units.J * units._hbar * 2 * np.pi * 1e15
+
+def _sparse_tensor_to_numpy(st):
+    """Convert a tf.SparseTensor to a picklable (indices, values, dense_shape) tuple."""
+    if st is None:
+        return None
+    return (st.indices.numpy(), st.values.numpy(), tuple(st.dense_shape.numpy()))
+
+
+def _numpy_to_sparse_tensor(data):
+    """Reconstruct a tf.SparseTensor from a (indices, values, dense_shape) tuple."""
+    if data is None:
+        return None
+    indices, values, dense_shape = data
+    return tf.SparseTensor(indices=indices, values=values, dense_shape=dense_shape)
+
+
+def _compute_kpoint_projection(index_k, n_modes, n_k_points, omega, physical_mode,
+                                evect_np, third_sparse_data, chi_k_np, velocity_np,
+                                cell_inv, kpts, broadening_shape, third_bandwidth,
+                                hbar, n_replicas, is_sparse, kpoint_maps):
+    """Compute sparse_phase and sparse_potential for all modes at one k-point.
+
+    All inputs are numpy arrays (picklable). TF tensors are created internally.
+    Returns a list of n_modes entries, each being:
+        (phase_data_list, potential_data_list)
+    where each *_data_list is [is_plus_0, is_plus_1] with entries as
+    (indices, values, dense_shape) numpy tuples or None.
+    """
+    # Pin BLAS threads in worker processes
+    os.environ['OMP_NUM_THREADS'] = '1'
+    os.environ['MKL_NUM_THREADS'] = '1'
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
+
+    # Reconstruct TF tensors from numpy
+    evect_tf = tf.cast(tf.convert_to_tensor(evect_np), dtype=tf.complex128)
+    second_minus = tf.math.conj(evect_tf)
+    _chi_k = tf.cast(tf.convert_to_tensor(chi_k_np), dtype=tf.complex128)
+    second_minus_chi = tf.math.conj(_chi_k)
+    velocity_tf = tf.convert_to_tensor(velocity_np)
+
+    if is_sparse:
+        coords, data, shape = third_sparse_data
+        third_tf = tf.SparseTensor(
+            tf.cast(coords, dtype=tf.int64), data, shape
+        )
+    else:
+        third_tf = tf.convert_to_tensor(third_sparse_data)
+    third_tf = tf.cast(third_tf, dtype=tf.complex128)
+
+    results = []
+    for mu in range(n_modes):
+        nu_single = index_k * n_modes + mu
+        if not physical_mode[index_k, mu]:
+            results.append(([None, None], [None, None]))
+            continue
+
+        phase_list = []
+        potential_list = []
+        for is_plus in (0, 1):
+            index_kpp_full = tf.cast(kpoint_maps[(index_k, is_plus)], dtype=tf.int32)
+            if third_bandwidth:
+                sigma_tf = tf.constant(third_bandwidth, dtype=tf.float64)
+            else:
+                sigma_tf = aha.calculate_broadening(velocity_tf, cell_inv, kpts, index_kpp_full)
+
+            dirac_delta_result = aha.calculate_dirac_delta_crystal(
+                omega, physical_mode, sigma_tf, broadening_shape,
+                index_kpp_full, index_k, mu, is_plus, n_k_points, n_modes,
+            )
+            if not dirac_delta_result:
+                phase_list.append(None)
+                potential_list.append(None)
+                continue
+
+            potential_result = aha.sparse_potential_mu(
+                nu_single, evect_tf, dirac_delta_result, index_k, mu,
+                n_k_points, n_modes, is_plus, is_sparse, index_kpp_full,
+                _chi_k, second_minus, second_minus_chi, third_tf,
+                n_replicas, omega, hbar,
+            )
+            phase_list.append(_sparse_tensor_to_numpy(dirac_delta_result))
+            potential_list.append(_sparse_tensor_to_numpy(potential_result))
+
+        results.append((phase_list, potential_list))
+    return results
+
+
+def _save_kpoint_projection(output_dir, index_k, results):
+    """Save per-k-point projection results to disk."""
+    save_dict = {}
+    for mu, (phase_list, pot_list) in enumerate(results):
+        for ip, (phase, pot) in enumerate(zip(phase_list, pot_list)):
+            prefix = f'mu{mu}_ip{ip}'
+            if phase is not None:
+                indices, values, dense_shape = phase
+                save_dict[f'{prefix}_phase_indices'] = indices
+                save_dict[f'{prefix}_phase_values'] = values
+                save_dict[f'{prefix}_phase_shape'] = np.array(dense_shape)
+            if pot is not None:
+                indices, values, dense_shape = pot
+                save_dict[f'{prefix}_pot_indices'] = indices
+                save_dict[f'{prefix}_pot_values'] = values
+                save_dict[f'{prefix}_pot_shape'] = np.array(dense_shape)
+    save_dict['n_modes'] = np.array(len(results))
+    np.savez(os.path.join(output_dir, f'kpt_{index_k:05d}.npz'), **save_dict)
+    # Sentinel is written by dispatch_with_resume after this returns.
+
+
+def _load_kpoint_projection(output_dir, index_k, n_modes):
+    """Load per-k-point projection results from disk."""
+    path = os.path.join(output_dir, f'kpt_{index_k:05d}.npz')
+    data = np.load(path, allow_pickle=False)
+    results = []
+    for mu in range(n_modes):
+        phase_list = []
+        pot_list = []
+        for ip in range(2):
+            prefix = f'mu{mu}_ip{ip}'
+            phase_key = f'{prefix}_phase_indices'
+            if phase_key in data:
+                phase_list.append((
+                    data[f'{prefix}_phase_indices'],
+                    data[f'{prefix}_phase_values'],
+                    tuple(data[f'{prefix}_phase_shape']),
+                ))
+            else:
+                phase_list.append(None)
+            pot_key = f'{prefix}_pot_indices'
+            if pot_key in data:
+                pot_list.append((
+                    data[f'{prefix}_pot_indices'],
+                    data[f'{prefix}_pot_values'],
+                    tuple(data[f'{prefix}_pot_shape']),
+                ))
+            else:
+                pot_list.append(None)
+        results.append((phase_list, pot_list))
+    return results
+
 
 class Phonons(Storable):
     """
@@ -164,8 +308,14 @@ class Phonons(Storable):
                  include_isotopes: bool = False,
                  iso_speed_up: bool = True,
                  is_nw: bool = False,
+                 n_workers: int = 1,
+                 projection_output_dir: str | None = None,
                  **kwargs):
         self.forceconstants = forceconstants
+        if n_workers is not None and n_workers < 1:
+            raise ValueError(f"n_workers must be >= 1 or None, got {n_workers}")
+        self.n_workers = n_workers
+        self.projection_output_dir = projection_output_dir
         self.is_classic = is_classic
         if temperature is not None:
             self.temperature = float(temperature)
@@ -1117,86 +1267,93 @@ class Phonons(Storable):
             sparse_third = self.forceconstants.third.value.reshape((self.n_modes, -1))
             sparse_coords = tf.stack([sparse_third.coords[1], sparse_third.coords[0]], -1)
             sparse_coords = tf.cast(sparse_coords, dtype=tf.int64)
-            third_tf = tf.SparseTensor(
-                sparse_coords, sparse_third.data, ((self.n_modes * n_replicas) ** 2, self.n_modes)
+            third_sparse_data = (
+                sparse_coords.numpy(),
+                sparse_third.data.astype(np.complex128) if sparse_third.data.dtype != np.complex128 else sparse_third.data,
+                ((self.n_modes * n_replicas) ** 2, self.n_modes),
             )
             is_sparse = True
         except AttributeError:
-            third_tf = tf.convert_to_tensor(self.forceconstants.third.value)
+            third_sparse_data = np.array(self.forceconstants.third.value)
             is_sparse = False
-        third_tf = tf.cast(third_tf, dtype=tf.complex128)
+
         k_mesh = self._reciprocal_grid.unitary_grid(is_wrapping=False)
         n_k_points = k_mesh.shape[0]
-        _chi_k = tf.convert_to_tensor(self.forceconstants.third._chi_k(k_mesh))
-        _chi_k = tf.cast(_chi_k, dtype=tf.complex128)
-        evect_tf = tf.convert_to_tensor(self._rescaled_eigenvectors)
-        evect_tf = tf.cast(evect_tf, dtype=tf.complex128)
-        second_minus = tf.math.conj(evect_tf)
-        second_minus_chi = tf.math.conj(_chi_k)
-        logging.info("Projection started")
-        broadening_shape = self.broadening_shape
+        chi_k_np = np.array(self.forceconstants.third._chi_k(k_mesh))
+        evect_np = np.array(self._rescaled_eigenvectors)
         physical_mode = self.physical_mode.reshape((self.n_k_points, self.n_modes))
         omega = self.omega
-        velocity_tf = tf.convert_to_tensor(self.velocity)
+        velocity_np = np.array(self.velocity)
         cell_inv = self.forceconstants.cell_inv
         kpts = self.kpts
         hbar = units._hbar
         n_modes = self.n_modes
-        n_phonons = self.n_phonons
+
+        # Pre-compute k-point mappings (avoids passing self to workers)
+        kpoint_maps = {}
+        for ik in range(n_k_points):
+            for is_plus in (0, 1):
+                kpoint_maps[(ik, is_plus)] = self._allowed_third_phonons_index(ik, is_plus)
+
+        logging.info("Projection started")
+
+        # Shared config for all k-point workers (all numpy, picklable)
+        shared = dict(
+            n_modes=n_modes, n_k_points=n_k_points, omega=omega,
+            physical_mode=physical_mode, evect_np=evect_np,
+            third_sparse_data=third_sparse_data, chi_k_np=chi_k_np,
+            velocity_np=velocity_np, cell_inv=cell_inv, kpts=kpts,
+            broadening_shape=self.broadening_shape,
+            third_bandwidth=self.third_bandwidth, hbar=hbar,
+            n_replicas=n_replicas, is_sparse=is_sparse,
+            kpoint_maps=kpoint_maps,
+        )
+
+        worker_fn = functools.partial(_compute_kpoint_projection, **shared)
+        output_dir = self.projection_output_dir
+
+        # Memory handling:
+        # - output_dir set: write to disk inside the loop and DROP the
+        #   in-memory result so peak memory stays at O(1) k-points. The
+        #   assembly loop later loads each k-point from disk one at a
+        #   time. This is the memory-bug fix vs. PR #231.
+        # - output_dir None: accumulate in a dict (legacy in-memory mode).
+        kpoint_results = {} if output_dir is None else None
+
+        for ik, result in dispatch_with_resume(
+            range(n_k_points), worker_fn,
+            n_workers=self.n_workers,
+            output_dir=output_dir,
+            sentinel_prefix="kpt_",
+            log_progress=False,
+        ):
+            if output_dir is not None:
+                _save_kpoint_projection(output_dir, ik, result)
+                # result dropped here — assembly loop reads from disk.
+            else:
+                kpoint_results[ik] = result
+            logging.info(f'Completed k-point {ik}/{n_k_points}')
+
+        # Assemble into the flat sparse_phase / sparse_potential lists
         sparse_phase = []
         sparse_potential = []
-        for nu_single in range(n_phonons):
-            if nu_single % 200 == 0:
-                logging.info(f"calculating third {nu_single}: {100 * nu_single / self.n_phonons:.2f}%")
-            sparse_phase.append([])
-            sparse_potential.append([])
-            index_k, mu = np.unravel_index(nu_single, (n_k_points, self.n_modes))
-            if not physical_mode[index_k, mu]:
-                sparse_phase[nu_single].extend([None, None])
-                sparse_potential[nu_single].extend([None, None])
-                continue
-            for is_plus in (0, 1):
-                index_kpp_full = tf.cast(self._allowed_third_phonons_index(index_k, is_plus), dtype=tf.int32)
-                if self.third_bandwidth:
-                    sigma_tf = tf.constant(self.third_bandwidth, dtype=tf.float64)
-                else:
-                    sigma_tf = aha.calculate_broadening(velocity_tf, cell_inv, kpts, index_kpp_full)
-                dirac_delta_result = aha.calculate_dirac_delta_crystal(
-                    omega,
-                    physical_mode,
-                    sigma_tf,
-                    broadening_shape,
-                    index_kpp_full,
-                    index_k,
-                    mu,
-                    is_plus,
-                    n_k_points,
-                    n_modes,
-                )
-                if not dirac_delta_result:
-                    sparse_phase[nu_single].append(None)
-                    sparse_potential[nu_single].append(None)
-                    continue
-                sparse_phase[nu_single].append(dirac_delta_result)
-                sparse_potential[nu_single].append(
-                    aha.sparse_potential_mu(
-                        nu_single,
-                        evect_tf,
-                        dirac_delta_result,
-                        index_k,
-                        mu,
-                        n_k_points,
-                        n_modes,
-                        is_plus,
-                        is_sparse,
-                        index_kpp_full,
-                        _chi_k,
-                        second_minus,
-                        second_minus_chi,
-                        third_tf,
-                        n_replicas,
-                        omega,
-                        hbar,
-                    )
-                )
+        for ik in range(n_k_points):
+            if kpoint_results is not None and ik in kpoint_results:
+                results = kpoint_results[ik]
+            elif output_dir:
+                results = _load_kpoint_projection(output_dir, ik, n_modes)
+            else:
+                raise RuntimeError(f'Missing results for k-point {ik}')
+
+            for mu in range(n_modes):
+                phase_list, pot_list = results[mu]
+                sparse_phase.append([
+                    _numpy_to_sparse_tensor(phase_list[0]),
+                    _numpy_to_sparse_tensor(phase_list[1]),
+                ])
+                sparse_potential.append([
+                    _numpy_to_sparse_tensor(pot_list[0]),
+                    _numpy_to_sparse_tensor(pot_list[1]),
+                ])
+
         return sparse_phase, sparse_potential

--- a/kaldo/tests/test_parallel_dispatcher.py
+++ b/kaldo/tests/test_parallel_dispatcher.py
@@ -1,0 +1,83 @@
+"""Unit tests for kaldo.parallel.dispatch_with_resume.
+
+These tests pin the dispatcher's contract: resume detection, sentinel
+atomicity, error propagation, and the serial/parallel parity that lets
+callers ignore which backend the executor picked.
+"""
+import os
+import time
+
+import pytest
+
+from kaldo.parallel import dispatch_with_resume
+
+
+def _identity(uid):
+    return uid * 2
+
+
+def test_empty_work_ids_yields_nothing(tmp_path):
+    results = list(dispatch_with_resume(
+        [], _identity, n_workers=1, output_dir=str(tmp_path),
+    ))
+    assert results == []
+
+
+def test_resume_skips_units_with_existing_sentinel(tmp_path):
+    """Units whose .done sentinel already exists must be skipped."""
+    for uid in (1, 3):
+        open(tmp_path / f"unit_{uid:05d}.done", "w").close()
+
+    out = sorted(dispatch_with_resume(
+        [0, 1, 2, 3, 4], _identity,
+        n_workers=1, output_dir=str(tmp_path),
+    ))
+
+    assert out == [(0, 0), (2, 4), (4, 8)]
+
+
+def test_resume_writes_sentinel_after_worker_returns(tmp_path):
+    """Sentinel must be created by the helper after the worker returns."""
+    list(dispatch_with_resume(
+        [0, 1], _identity, n_workers=1, output_dir=str(tmp_path),
+    ))
+
+    assert (tmp_path / "unit_00000.done").exists()
+    assert (tmp_path / "unit_00001.done").exists()
+
+
+def test_no_output_dir_means_no_sentinel(tmp_path):
+    """When output_dir is None the helper writes nothing to disk."""
+    list(dispatch_with_resume(
+        [0, 1], _identity, n_workers=1, output_dir=None,
+    ))
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def _raises_for_unit_one(uid):
+    if uid == 1:
+        raise RuntimeError("worker exploded")
+    return uid
+
+
+def test_failed_worker_leaves_no_sentinel(tmp_path):
+    """If the worker raises, no sentinel exists for that unit."""
+    with pytest.raises(RuntimeError, match="worker exploded"):
+        list(dispatch_with_resume(
+            [0, 1, 2], _raises_for_unit_one,
+            n_workers=1, output_dir=str(tmp_path),
+        ))
+
+    assert not (tmp_path / "unit_00001.done").exists()
+
+
+def test_parallel_backend_matches_serial(tmp_path):
+    """Parallel and serial backends produce the same set of results."""
+    serial = dict(dispatch_with_resume(
+        list(range(8)), _identity, n_workers=1,
+    ))
+    parallel = dict(dispatch_with_resume(
+        list(range(8)), _identity, n_workers=2,
+    ))
+    assert serial == parallel

--- a/kaldo/tests/test_parallel_executor.py
+++ b/kaldo/tests/test_parallel_executor.py
@@ -117,3 +117,16 @@ def test_require_main_process_no_op_in_main_process():
     _require_main_process(n_workers=None)
     _require_main_process(n_workers=4)
     _require_main_process(n_workers=1)
+
+
+def test_default_mp_context_picks_spawn_when_tf_loaded(monkeypatch):
+    """When TensorFlow is imported in the parent, fork is unsafe (TF eagerly
+    creates threads at import; forking leaves the child's runtime in a
+    half-initialized state, causing silent deadlocks under xdist + parallel
+    kaldo — see PR #231 CI hang). The context picker must avoid fork.
+    """
+    import sys as _sys
+    from kaldo.parallel.executor import _default_mp_context
+    monkeypatch.setitem(_sys.modules, 'tensorflow', object())
+    ctx = _default_mp_context()
+    assert ctx.get_start_method() == 'spawn'

--- a/kaldo/tests/test_parallel_executor.py
+++ b/kaldo/tests/test_parallel_executor.py
@@ -24,7 +24,13 @@ def _report_thread_caps(_=None):
     }
 
 
-def test_default_worker_caps_threads_to_one():
+def test_default_worker_caps_threads_to_one(monkeypatch):
+    # Same env hygiene as test_worker_threads_override: under spawn the
+    # worker inherits the parent's env, so any pre-set OMP_NUM_THREADS
+    # would short-circuit the cap. Clear the env first.
+    for var in ('OMP_NUM_THREADS', 'MKL_NUM_THREADS', 'OPENBLAS_NUM_THREADS',
+                'NUMEXPR_NUM_THREADS', 'VECLIB_MAXIMUM_THREADS'):
+        monkeypatch.delenv(var, raising=False)
     with get_executor(backend='process', n_workers=2) as executor:
         result = executor.submit(_report_thread_caps).result()
     assert result['OMP_NUM_THREADS'] == '1'
@@ -32,7 +38,16 @@ def test_default_worker_caps_threads_to_one():
     assert result['OPENBLAS_NUM_THREADS'] == '1'
 
 
-def test_worker_threads_override():
+def test_worker_threads_override(monkeypatch):
+    # Clear inherited caps so the worker starts in the unset state the
+    # _init_worker_thread_caps docstring describes ("user-set caps are
+    # respected; unset variables are capped to n_threads"). Without this,
+    # spawn-context workers inherit whatever the parent xdist worker has
+    # in its env (often OMP_NUM_THREADS=1 from a previous test), which
+    # silently overrides the n_threads argument we're trying to verify.
+    for var in ('OMP_NUM_THREADS', 'MKL_NUM_THREADS', 'OPENBLAS_NUM_THREADS',
+                'NUMEXPR_NUM_THREADS', 'VECLIB_MAXIMUM_THREADS'):
+        monkeypatch.delenv(var, raising=False)
     with get_executor(backend='process', n_workers=2, worker_threads=4) as executor:
         result = executor.submit(_report_thread_caps).result()
     assert result['OMP_NUM_THREADS'] == '4'

--- a/kaldo/tests/test_parallel_projection.py
+++ b/kaldo/tests/test_parallel_projection.py
@@ -1,0 +1,149 @@
+"""Tests for parallel per-k-point projection in _project_crystal.
+
+Validates that parallel projection (n_workers > 1) produces numerically
+identical sparse_phase and sparse_potential tensors as the serial path.
+"""
+
+import numpy as np
+import pytest
+from kaldo.forceconstants import ForceConstants
+from kaldo.phonons import Phonons
+
+
+@pytest.fixture(scope="module")
+def si_forceconstants():
+    """Load Si crystal force constants (shared across all tests in module)."""
+    return ForceConstants.from_folder("kaldo/tests/si-crystal", supercell=(3, 3, 3), format="eskm")
+
+
+@pytest.fixture(scope="module")
+def serial_phonons(si_forceconstants):
+    """Compute projection serially (baseline)."""
+    return Phonons(
+        forceconstants=si_forceconstants,
+        kpts=(3, 3, 3),
+        temperature=300,
+        is_classic=True,
+        folder="test_serial_projection",
+        n_workers=1,
+    )
+
+
+def test_parallel_projection_matches_serial(si_forceconstants, serial_phonons):
+    """Parallel projection (2 workers) must match serial at rtol=1e-7."""
+    parallel = Phonons(
+        forceconstants=si_forceconstants,
+        kpts=(3, 3, 3),
+        temperature=300,
+        is_classic=True,
+        folder="test_parallel_projection",
+        n_workers=2,
+    )
+
+    phase_s = serial_phonons.sparse_phase
+    phase_p = parallel.sparse_phase
+    pot_s = serial_phonons.sparse_potential
+    pot_p = parallel.sparse_potential
+
+    assert len(phase_s) == len(phase_p), "sparse_phase length mismatch"
+    assert len(pot_s) == len(pot_p), "sparse_potential length mismatch"
+
+    for nu in range(len(phase_s)):
+        for ip in range(2):
+            ps = phase_s[nu][ip]
+            pp = phase_p[nu][ip]
+            if ps is None:
+                assert pp is None, f"Phase mismatch at nu={nu}, is_plus={ip}: serial is None, parallel is not"
+                continue
+            assert pp is not None, f"Phase mismatch at nu={nu}, is_plus={ip}: serial has data, parallel is None"
+            np.testing.assert_allclose(
+                ps.values.numpy(), pp.values.numpy(), rtol=1e-7,
+                err_msg=f"Phase values differ at nu={nu}, is_plus={ip}",
+            )
+            np.testing.assert_array_equal(
+                ps.indices.numpy(), pp.indices.numpy(),
+                err_msg=f"Phase indices differ at nu={nu}, is_plus={ip}",
+            )
+
+            # Also check potential
+            ss = pot_s[nu][ip]
+            sp = pot_p[nu][ip]
+            if ss is None:
+                assert sp is None
+                continue
+            np.testing.assert_allclose(
+                ss.values.numpy(), sp.values.numpy(), rtol=1e-7,
+                err_msg=f"Potential values differ at nu={nu}, is_plus={ip}",
+            )
+
+
+def test_projection_output_dir_with_resume(si_forceconstants, serial_phonons, tmp_path):
+    """Disk-based projection with resume produces correct results."""
+    output_dir = str(tmp_path / "projection_output")
+
+    # Full run with output to disk
+    p1 = Phonons(
+        forceconstants=si_forceconstants,
+        kpts=(3, 3, 3),
+        temperature=300,
+        is_classic=True,
+        folder="test_output_dir_proj",
+        n_workers=2,
+        projection_output_dir=output_dir,
+    )
+    phase_disk = p1.sparse_phase
+
+    # Verify matches serial
+    phase_s = serial_phonons.sparse_phase
+    for nu in range(len(phase_s)):
+        for ip in range(2):
+            ps = phase_s[nu][ip]
+            pd = phase_disk[nu][ip]
+            if ps is None:
+                assert pd is None
+                continue
+            np.testing.assert_allclose(
+                ps.values.numpy(), pd.values.numpy(), rtol=1e-7,
+                err_msg=f"Disk phase values differ at nu={nu}, is_plus={ip}",
+            )
+
+
+def test_n_workers_zero_raises():
+    """n_workers=0 should raise ValueError."""
+    fc = ForceConstants.from_folder("kaldo/tests/si-crystal", supercell=(3, 3, 3), format="eskm")
+    with pytest.raises(ValueError, match="n_workers must be >= 1"):
+        Phonons(forceconstants=fc, kpts=(3, 3, 3), temperature=300, n_workers=0)
+
+
+def test_output_dir_writes_files_for_every_kpoint(si_forceconstants, tmp_path):
+    """When projection_output_dir is set, every k-point's .npz must exist
+    on disk after the run (not just the sentinel). Regression for the
+    PR #231 memory bug: the old code accumulated results in memory and
+    only wrote files at the end; this test pins that the new code writes
+    inside the dispatch loop (and drops the in-memory copy).
+    """
+    import os
+    import glob
+
+    output_dir = str(tmp_path / "kpt_out")
+    phonons = Phonons(
+        forceconstants=si_forceconstants,
+        kpts=(3, 3, 3),
+        temperature=300,
+        is_classic=True,
+        folder=str(tmp_path / "phonons_folder"),
+        projection_output_dir=output_dir,
+        n_workers=1,
+    )
+    _ = phonons.sparse_phase
+
+    npz_files = sorted(glob.glob(os.path.join(output_dir, "kpt_*.npz")))
+    done_files = sorted(glob.glob(os.path.join(output_dir, "kpt_*.done")))
+
+    # 3x3x3 mesh = 27 k-points
+    assert len(npz_files) == 27, (
+        f"Expected 27 .npz files, got {len(npz_files)}: {npz_files}"
+    )
+    assert len(done_files) == 27, (
+        f"Expected 27 .done sentinels, got {len(done_files)}"
+    )


### PR DESCRIPTION
## Summary

Parallelizes the per-k-point crystal projection across workers using the
`get_executor()` abstraction introduced in #228, and extracts the
duplicated dispatch+resume loop into one shared helper.

## What's new

1. **`kaldo.parallel.dispatch_with_resume()`** — single helper that owns
   the dispatch + resume + sentinel-write loop, replacing three
   copy-pasted versions. Workers write their own output files; the
   helper writes the `.done` sentinel only after the worker returns
   successfully (atomicity: no sentinel without a complete result).

2. **Parallel per-k-point crystal projection** — `_project_crystal()`
   extracts per-k-point work into a free `_compute_kpoint_projection()`
   function (numpy in, TF tensors created internally so it's
   spawn/forkserver-safe). Each k-point's modes are computed
   independently in its own worker.

3. **Disk-based projection output with resume** — optional
   `projection_output_dir` parameter on `Phonons` writes per-k-point
   `kpt_NNNNN.npz` files plus `.done` sentinels. Interrupted runs
   resume by skipping completed k-points, matching the FC scratch-file
   pattern.

4. **Memory fix in `_project_crystal`** — the previous draft of this
   PR accumulated all per-k-point results in a dict before optionally
   writing them to disk, defeating `projection_output_dir` for large
   k-meshes. Results are now flushed inside the dispatch loop and
   dropped from memory; assembly loads each k-point back from disk one
   at a time.

5. **Migrations** — `calculate_second()`, `calculate_third()`, and
   `_project_crystal()` all now use `dispatch_with_resume()`.
   `displacement.py` shrinks by ~40 lines net.

6. **Spawn-when-TF-loaded** — `_default_mp_context()` already picked
   `spawn` when CUDA was available; it now also does so when
   TensorFlow is imported in the parent process. TF eagerly creates a
   thread pool at import; forking duplicates the FDs but not the
   threads, leaving the worker's TF runtime in a half-initialized
   state. Symptoms range from silent deadlocks to
   `CUDA_ERROR_INVALID_HANDLE`. xdist + parallel kaldo on Linux
   reliably tickles this — exposed by this PR's CI hang on the first
   push.

## What's parallelized now

| Stage | Work unit | Pattern |
|-------|-----------|---------|
| FC generation (#228) | per-atom | `dispatch_with_resume()` + scratch files |
| Crystal projection (this PR) | per-k-point | `dispatch_with_resume()` + output files |
| Amorphous projection | serial (1 k-point) | unchanged |

## Verification

- New unit tests for the dispatcher (`test_parallel_dispatcher.py`):
  empty-input, resume-skips-existing-sentinel, sentinel-on-success,
  no-sentinel-without-output-dir, no-sentinel-on-worker-failure,
  parallel-matches-serial.
- New unit test for the spawn-when-TF behavior in
  `test_parallel_executor.py`.
- New regression test in `test_parallel_projection.py` for the memory
  fix: with `projection_output_dir` set, every k-point's `.npz` exists
  on disk after the run.
- Pre-existing `test_parallel_second.py` and `test_parallel_third.py`
  continue to pass after the dispatcher migration.
- CI green (164 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Parallel k-point projection for crystalline systems with configurable worker processes
  * Resume capability for interrupted projections using on-disk checkpoints
  * New `n_workers` and `projection_output_dir` parameters in Phonons class

* **Improvements**
  * Enhanced multiprocessing context selection to safely handle TensorFlow and CUDA libraries

* **Refactor**
  * Unified parallel execution workflow for improved consistency and maintainability

* **Tests**
  * Comprehensive test coverage for parallel dispatcher, executor, and projection workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->