### PR TITLE
Remove unused Git LFS tracking

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,5 @@
-# large data file
-examples/germanium_espresso_d3q/fc/FORCE_CONSTANTS_3RD filter=lfs diff=lfs merge=lfs -text
-examples/germanium_espresso_d3q/fc/espresso.ifc2 filter=lfs diff=lfs merge=lfs -text
-examples/mgo_espresso_d3q/data/mgo-qe-d3q.tgz filter=lfs diff=lfs merge=lfs -text
-
 # data file in tests
-# Note: To make CI easier to work with, data file in tests should stay in the git repo. 
+# Note: To make CI easier to work with, data file in tests should stay in the git repo.
 # cannot automatically merge, must be treated as a whole
 # do not generate textual diff
 # keep EOL char of text file consistant for human-readable data file, turn it off for binary file


### PR DESCRIPTION
The `examples/` directory with LFS-tracked files (`germanium_espresso_d3q`, `mgo_espresso_d3q`) was removed from the repo. This removes the stale LFS tracking rules from `.gitattributes`.

One-line change, no code impact.