### PR TITLE
Fix dtype mismatch when loading float32 third-order force constants

### DIFF
--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -92,7 +92,8 @@ class ThirdOrder(ForceConstant):
                               pbc=[1, 1, 1])
 
                 _third_order = COO.from_scipy_sparse(load_npz(os.path.join(folder, THIRD_ORDER_FILE_SPARSE))) \
-                    .reshape((n_unit_atoms * 3, n_replicas * n_unit_atoms * 3, n_replicas * n_unit_atoms * 3))
+                    .reshape((n_unit_atoms * 3, n_replicas * n_unit_atoms * 3, n_replicas * n_unit_atoms * 3)) \
+                    .astype(np.float64)
                 third_order = ThirdOrder(atoms=atoms,
                                          replicated_positions=replicated_atoms.positions,
                                          supercell=supercell,


### PR DESCRIPTION
Large amorphous systems (e.g. 1920-atom amorphous carbon) often save `third.npz` as float32 to reduce memory. This causes a dtype mismatch at `phonons.py:1095` where TF requires matching dtypes for sparse-dense matmul. The existing crystal path (`_project_crystal`) already casts to a common dtype, but the amorphous path did not.

This PR, ensure float64 dtype when loading third-order force constants from `third.npz` in `ThirdOrder.load`. Fixes TensorFlow `SparseTensorDenseMatMul` crash in `_project_amorphous` when third-order data is float32 but eigenvectors are float64

Closes #235
