### PR TITLE
Finalization of realspace symmetry for second and third order

### DIFF
--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -9,6 +9,235 @@ from sparse import COO
 logging = get_logger()
 
 
+def get_equivalent_ifc_indices(atoms, supercell, symprec=1e-5, order=2):
+    """Determine symmetrically equivalent IFC block indices for 2nd and 3rd order.
+
+    Groups every (i, l_j, j) second-order and (i, l_j, j, l_k, k) third-order
+    atom-tuple into equivalence classes under the crystal spacegroup. Two blocks
+    belong to the same class when a spacegroup operation maps one to the other;
+    their IFC tensors are then related by a Cartesian similarity transform:
+
+        2nd order:  Phi[i,:,l_j,j,:]         = R @ Phi[canonical] @ R.T
+        3rd order:  Phi[i,:,l_j,j,:,l_k,k,:] = einsum('ai,bj,ck,ijk', R, R, R, Phi[canonical])
+
+    where (canonical) is the lowest flat-index representative of the class and
+    R is the Cartesian rotation stored in the corresponding rot_map.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Unit cell with valid cell vectors and periodic boundary conditions.
+    supercell : tuple of int, length 3
+        Supercell repetitions (nx, ny, nz).
+    symprec : float, optional
+        Symmetry detection tolerance passed to spglib (default 1e-5).
+    order : int, optional
+        2 or 3 (default 2). Passing 2 skips all third-order work.
+
+    Returns
+    -------
+    irr_map_2 : ndarray, shape (n_unit, n_replicas, n_unit)
+        Flat canonical index for each 2nd-order block.
+    rot_map_2 : ndarray, shape (n_unit, n_replicas, n_unit, 3, 3)
+        Cartesian rotation R such that Phi2[i,:,l,j,:] = R @ Phi2[canonical] @ R.T.
+    irr_map_3 : ndarray or None, shape (n_unit, n_replicas, n_unit, n_replicas, n_unit)
+        Flat canonical index for each 3rd-order block (None when order < 3).
+    rot_map_3 : ndarray or None, shape (n_unit, n_replicas, n_unit, n_replicas, n_unit, 3, 3)
+        Cartesian rotation for each 3rd-order block (None when order < 3).
+    """
+    try:
+        import spglib
+    except ImportError as exc:
+        raise ImportError("spglib is required. Install with: pip install spglib") from exc
+
+    n_unit = len(atoms)
+    nx, ny, nz = supercell
+    n_replicas = nx * ny * nz
+    supercell_shape = np.array([nx, ny, nz], dtype=int)
+    grid = np.array(list(np.ndindex(nx, ny, nz)), dtype=int)
+
+    n_blocks_2 = n_unit * n_replicas * n_unit
+    n_blocks_3 = n_unit * n_replicas * n_unit * n_replicas * n_unit if order >= 3 else 0
+
+    s3_i  = n_replicas * n_unit * n_replicas * n_unit
+    s3_lj = n_unit * n_replicas * n_unit
+    s3_j  = n_replicas * n_unit
+    s3_lk = n_unit
+
+    lattice = atoms.cell[:]
+    scaled_pos = atoms.get_scaled_positions()
+    dataset = spglib.get_symmetry_dataset(
+        (lattice, scaled_pos, atoms.numbers), symprec=symprec
+    )
+    if dataset is None:
+        raise ValueError(
+            f"spglib could not determine symmetry (symprec={symprec}). "
+            "Try adjusting symprec or relaxing the structure."
+        )
+
+    rotations    = dataset.rotations
+    translations = dataset.translations
+    n_ops = len(rotations)
+    logging.info(
+        f"Space group: {dataset.international} (#{dataset.number}), "
+        f"{n_ops} symmetry operations"
+    )
+
+    AT = lattice.T
+    rotations_cart = np.einsum('ij,kjl,lm->kim', AT, rotations, np.linalg.inv(AT))
+
+    atom_map    = np.empty((n_ops, n_unit), dtype=int)
+    cell_shifts = np.zeros((n_ops, n_unit, 3), dtype=int)
+
+    for k in range(n_ops):
+        R, t = rotations[k], translations[k]
+        imgs    = scaled_pos @ R.T + t[np.newaxis, :]
+        shifts  = np.floor(imgs + 0.5 * symprec).astype(int)
+        imgs_w  = imgs - shifts
+        for i in range(n_unit):
+            diffs = imgs_w[i] - scaled_pos
+            diffs -= np.round(diffs)
+            norms = np.linalg.norm(diffs, axis=1)
+            ip = int(np.argmin(norms))
+            if norms[ip] > symprec * 10:
+                raise RuntimeError(
+                    f"Atom image lookup failed for op {k}, atom {i}. "
+                    "Increase symprec or check the structure."
+                )
+            atom_map[k, i]    = ip
+            cell_shifts[k, i] = shifts[i]
+
+    parent2 = np.arange(n_blocks_2)
+    parent3 = np.arange(n_blocks_3) if order >= 3 else None
+
+    def _find(parent, x):
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    if order >= 3:
+        LJ_flat, LK_flat = np.mgrid[0:n_replicas, 0:n_replicas]
+        LJ_flat = LJ_flat.ravel()
+        LK_flat = LK_flat.ravel()
+        n_pairs = n_replicas * n_replicas
+
+    for k in range(n_ops):
+        R_int = rotations[k]
+        for i in range(n_unit):
+            ip = atom_map[k, i]
+            for j in range(n_unit):
+                jp = atom_map[k, j]
+                col_shift_j = cell_shifts[k, j] - cell_shifts[k, i]
+                g_new_j   = grid @ R_int.T + col_shift_j[np.newaxis, :]
+                g_new_j_w = g_new_j % supercell_shape[np.newaxis, :]
+                l_j_new   = (g_new_j_w[:, 0] * ny * nz
+                             + g_new_j_w[:, 1] * nz
+                             + g_new_j_w[:, 2])
+
+                base_orig2 = i  * n_replicas * n_unit + j
+                base_new2  = ip * n_replicas * n_unit + jp
+                for l in range(n_replicas):
+                    f_orig = base_orig2 + l                * n_unit
+                    f_new  = base_new2  + int(l_j_new[l]) * n_unit
+                    r_o, r_n = _find(parent2, f_orig), _find(parent2, f_new)
+                    if r_o != r_n:
+                        if r_o < r_n: parent2[r_n] = r_o
+                        else:         parent2[r_o] = r_n
+
+                if order >= 3:
+                    for k_atom in range(n_unit):
+                        kp = atom_map[k, k_atom]
+                        col_shift_k = cell_shifts[k, k_atom] - cell_shifts[k, i]
+                        g_new_k   = grid @ R_int.T + col_shift_k[np.newaxis, :]
+                        g_new_k_w = g_new_k % supercell_shape[np.newaxis, :]
+                        l_k_new   = (g_new_k_w[:, 0] * ny * nz
+                                     + g_new_k_w[:, 1] * nz
+                                     + g_new_k_w[:, 2])
+
+                        LJ_new = l_j_new[LJ_flat]
+                        LK_new = l_k_new[LK_flat]
+                        f_orig3 = (i  * s3_i + LJ_flat * s3_lj + j  * s3_j + LK_flat * s3_lk + k_atom)
+                        f_new3  = (ip * s3_i + LJ_new  * s3_lj + jp * s3_j + LK_new  * s3_lk + kp)
+
+                        for idx in range(n_pairs):
+                            r_o = _find(parent3, int(f_orig3[idx]))
+                            r_n = _find(parent3, int(f_new3[idx]))
+                            if r_o != r_n:
+                                if r_o < r_n: parent3[r_n] = r_o
+                                else:         parent3[r_o] = r_n
+
+    canonical2 = np.array([_find(parent2, f) for f in range(n_blocks_2)])
+    irr_map_2  = canonical2.reshape(n_unit, n_replicas, n_unit)
+    n_irr2 = len(np.unique(canonical2))
+    logging.info(
+        f"2nd-order IFC: {n_irr2} irreducible / {n_blocks_2} total blocks "
+        f"({100.0 * n_irr2 / n_blocks_2:.1f}%)"
+    )
+
+    if order >= 3:
+        canonical3 = np.array([_find(parent3, f) for f in range(n_blocks_3)])
+        irr_map_3  = canonical3.reshape(n_unit, n_replicas, n_unit, n_replicas, n_unit)
+        n_irr3 = len(np.unique(canonical3))
+        logging.info(
+            f"3rd-order IFC: {n_irr3} irreducible / {n_blocks_3} total blocks "
+            f"({100.0 * n_irr3 / n_blocks_3:.1f}%)"
+        )
+    else:
+        canonical3 = None
+        irr_map_3  = None
+
+    rot_map_2 = np.broadcast_to(np.eye(3), (n_unit, n_replicas, n_unit, 3, 3)).copy()
+    if order >= 3:
+        rot_map_3 = np.broadcast_to(
+            np.eye(3), (n_unit, n_replicas, n_unit, n_replicas, n_unit, 3, 3)
+        ).copy()
+    else:
+        rot_map_3 = None
+
+    l_arr = np.arange(n_replicas)
+
+    for k in range(n_ops):
+        R_int = rotations[k]
+        R_inv = rotations_cart[k].T
+        for i in range(n_unit):
+            ip = atom_map[k, i]
+            for j in range(n_unit):
+                jp = atom_map[k, j]
+                col_shift_j = cell_shifts[k, j] - cell_shifts[k, i]
+                g_new_j   = grid @ R_int.T + col_shift_j[np.newaxis, :]
+                g_new_j_w = g_new_j % supercell_shape[np.newaxis, :]
+                l_j_new   = (g_new_j_w[:, 0] * ny * nz
+                             + g_new_j_w[:, 1] * nz
+                             + g_new_j_w[:, 2])
+
+                f_orig2 = i  * n_replicas * n_unit + l_arr * n_unit + j
+                f_new2  = ip * n_replicas * n_unit + l_j_new * n_unit + jp
+                mask2   = (canonical2[f_orig2] == f_new2) & (f_orig2 != f_new2)
+                rot_map_2[i, l_arr[mask2], j] = R_inv
+
+                if order >= 3:
+                    for k_atom in range(n_unit):
+                        kp = atom_map[k, k_atom]
+                        col_shift_k = cell_shifts[k, k_atom] - cell_shifts[k, i]
+                        g_new_k   = grid @ R_int.T + col_shift_k[np.newaxis, :]
+                        g_new_k_w = g_new_k % supercell_shape[np.newaxis, :]
+                        l_k_new   = (g_new_k_w[:, 0] * ny * nz
+                                     + g_new_k_w[:, 1] * nz
+                                     + g_new_k_w[:, 2])
+
+                        LJ_new = l_j_new[LJ_flat]
+                        LK_new = l_k_new[LK_flat]
+                        f_orig3 = (i  * s3_i + LJ_flat * s3_lj + j  * s3_j + LK_flat * s3_lk + k_atom)
+                        f_new3  = (ip * s3_i + LJ_new  * s3_lj + jp * s3_j + LK_new  * s3_lk + kp)
+                        mask3   = (canonical3[f_orig3] == f_new3) & (f_orig3 != f_new3)
+                        if np.any(mask3):
+                            rot_map_3[i, LJ_flat[mask3], j, LK_flat[mask3], k_atom] = R_inv
+
+    return irr_map_2, rot_map_2, irr_map_3, rot_map_3
+
 
 def list_of_replicas(atoms, replicated_atoms):
     n_atoms = atoms.positions.shape[0]
@@ -34,7 +263,7 @@ def calculate_gradient(x, input_atoms):
 
 
 def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=False, n_workers=1, calculator=None,
-                     scratch_dir=None, keep_scratch=False):
+                     scratch_dir=None, keep_scratch=False, use_symmetry=False, symprec=1e-5):
     """
     Core method to compute second order force constant matrices
     Approximate the second order force constant matrices
@@ -47,6 +276,11 @@ def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=Fal
             validate_parallel_calculator(calculator, method='calculate_second')
         elif getattr(replicated_atoms, 'calc', None) is not None:
             validate_parallel_calculator(replicated_atoms.calc, method='calculate_second')
+    if use_symmetry and scratch_dir is not None:
+        raise ValueError(
+            "use_symmetry=True is not compatible with scratch_dir. "
+            "Set scratch_dir=None when using symmetry reduction."
+        )
 
     logging.info('Calculating second order potential derivatives, ' + 'finite difference displacement: %.3e angstrom'%second_order_delta)
     n_unit_cell_atoms = len(atoms.numbers)
@@ -66,6 +300,24 @@ def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=Fal
     else:
         second = np.zeros((n_atoms, 3, n_replicated_atoms * 3))
         atoms_to_compute = list(range(n_atoms))
+
+    if use_symmetry:
+        # Assumes diagonal supercell expansion; np.diag discards off-diagonal elements
+        supercell = tuple(np.diag(np.round(replicated_atoms.cell @ np.linalg.inv(atoms.cell)).astype(int)))
+        irr_map_2, rot_map_2, _, _ = get_equivalent_ifc_indices(
+            atoms, supercell, symprec=symprec, order=2
+        )
+        i0_all, l0_all, j0_all = np.unravel_index(
+            irr_map_2.ravel(), (n_atoms, n_replicas, n_atoms)
+        )
+        atoms_to_compute = np.unique(i0_all).tolist()
+        logging.info(
+            f'Symmetry reduction: displacing {len(atoms_to_compute)}/{n_atoms} atoms'
+        )
+    else:
+        irr_map_2 = rot_map_2 = None
+        i0_all = l0_all = j0_all = None
+
     use_parallel = n_workers is None or n_workers > 1
     backend = 'process' if use_parallel else 'serial'
     executor_workers = n_workers if use_parallel else None
@@ -93,6 +345,18 @@ def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=Fal
 
     second = second.reshape((1, n_unit_cell_atoms, 3, n_replicas, n_unit_cell_atoms, 3))
     second = second / (2. * second_order_delta)
+
+    if use_symmetry:
+        # Reconstruct non-irreducible blocks: Phi[i,:,l,j,:] = R @ Phi[canonical] @ R.T
+        phi = second[0]                                              # (n_unit, 3, n_repl, n_unit, 3)
+        Phi_canon = phi[i0_all, :, l0_all, j0_all, :]               # (n_blocks_2, 3, 3)
+        R = rot_map_2.reshape(-1, 3, 3)                              # (n_blocks_2, 3, 3)
+        second_flat = R @ Phi_canon @ R.transpose(0, 2, 1)           # (n_blocks_2, 3, 3)
+        second = (second_flat
+                  .reshape(n_unit_cell_atoms, n_replicas, n_unit_cell_atoms, 3, 3)
+                  .transpose(0, 3, 1, 2, 4)
+                  [np.newaxis])
+
     asymmetry = np.sum(np.abs(second[0, :, :, 0, :, :] - np.transpose(second[0, :, :, 0, :, :], (2, 3, 0, 1))))
     logging.info('Symmetry of Dynamical Matrix ' + str(asymmetry))
     return second
@@ -146,7 +410,7 @@ def _assemble_from_scratch_second(scratch_dir, n_atoms, n_replicated_atoms, keep
 
 def calculate_third(atoms, replicated_atoms, third_order_delta, distance_threshold=None, is_verbose=False,
                     n_workers=1, calculator=None, scratch_dir=None, keep_scratch=False,
-                    jat_flush_every=50):
+                    jat_flush_every=50, use_symmetry=False, symprec=1e-5):
     """
     Compute third order force constant matrices by using the central
     difference formula for the approximation.
@@ -200,6 +464,11 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
             validate_parallel_calculator(calculator, method='calculate_third')
         elif getattr(replicated_atoms, 'calc', None) is not None:
             validate_parallel_calculator(replicated_atoms.calc, method='calculate_third')
+    if use_symmetry and scratch_dir is not None:
+        raise ValueError(
+            "use_symmetry=True is not compatible with scratch_dir. "
+            "Set scratch_dir=None when using symmetry reduction."
+        )
 
     logging.info('Calculating third order potential derivatives, ' + 'finite difference displacement: %.3e angstrom'%third_order_delta)
     n_atoms = len(atoms.numbers)
@@ -218,17 +487,41 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     n_forces_done = 0
     n_forces_skipped = 0
 
-    use_parallel = n_workers is None or n_workers > 1
-
-    # Determine which atoms need computing (resume support via scratch sentinels)
-    if use_scratch:
-        atoms_to_compute = [iat for iat in range(n_atoms)
-                             if not os.path.exists(os.path.join(scratch_dir, f'iat_{iat:05d}.done'))]
-        n_resumed = n_atoms - len(atoms_to_compute)
-        if n_resumed:
-            logging.info(f'Resuming: skipping {n_resumed} already-computed atom(s)')
+    # Build per-iat allowed_jat mapping from irreducible pair set when using symmetry
+    if use_symmetry:
+        # Assumes diagonal supercell expansion; np.diag discards off-diagonal elements
+        supercell = tuple(np.diag(np.round(replicated_atoms.cell @ np.linalg.inv(atoms.cell)).astype(int)))
+        _, _, irr_map_3, rot_map_3 = get_equivalent_ifc_indices(
+            atoms, supercell, symprec=symprec, order=3
+        )
+        i0_all, lj0_all, j0_all, _, _ = np.unravel_index(
+            irr_map_3.ravel(), (n_atoms, n_replicas, n_atoms, n_replicas, n_atoms)
+        )
+        irr_pairs = np.unique(
+            np.stack([i0_all, lj0_all * n_atoms + j0_all], axis=1), axis=0
+        )
+        allowed_jat_per_iat = {}
+        for i0, jat0 in irr_pairs:
+            allowed_jat_per_iat.setdefault(int(i0), set()).add(int(jat0))
+        atoms_to_compute = sorted(allowed_jat_per_iat.keys())
+        logging.info(
+            f'Symmetry reduction: {len(irr_pairs)} irreducible / '
+            f'{n_atoms * n_replicas * n_atoms} total atom pairs'
+        )
     else:
-        atoms_to_compute = list(range(n_atoms))
+        irr_map_3 = rot_map_3 = None
+        allowed_jat_per_iat = {}
+        # Determine which atoms need computing (resume support via scratch sentinels)
+        if use_scratch:
+            atoms_to_compute = [iat for iat in range(n_atoms)
+                                 if not os.path.exists(os.path.join(scratch_dir, f'iat_{iat:05d}.done'))]
+            n_resumed = n_atoms - len(atoms_to_compute)
+            if n_resumed:
+                logging.info(f'Resuming: skipping {n_resumed} already-computed atom(s)')
+        else:
+            atoms_to_compute = list(range(n_atoms))
+
+    use_parallel = n_workers is None or n_workers > 1
 
     # Select backend: 'process' for parallel, 'serial' for single-threaded
     backend = 'process' if use_parallel else 'serial'
@@ -244,7 +537,8 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     with get_executor(backend=backend, n_workers=executor_workers) as executor:
         futures = {
             executor.submit(worker_fn, iat, atoms, replicated_atoms,
-                           third_order_delta, distance_threshold, is_verbose): iat
+                           third_order_delta, distance_threshold, is_verbose,
+                           allowed_jat=allowed_jat_per_iat.get(iat)): iat
             for iat in atoms_to_compute
         }
         for future in as_completed(futures):
@@ -270,6 +564,74 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     logging.info('forces skipped (outside distance threshold) : ' + str(n_forces_skipped))
     if use_scratch:
         return _assemble_from_scratch_third(scratch_dir, n_atoms, n_replicas, keep_scratch)
+
+    if use_symmetry:
+        # Expand irreducible sparse entries to the full tensor via symmetry.
+        n_rep_atoms = n_replicas * n_atoms
+
+        phi_irr = {}
+        for iat, ic, jat, jc, k, v in zip(i_at_sparse, i_coord_sparse, jat_sparse,
+                                            j_coord_sparse, k_sparse, value_sparse):
+            key = (int(iat), int(jat))
+            if key not in phi_irr:
+                phi_irr[key] = np.zeros((3, 3, n_rep_atoms * 3))
+            phi_irr[key][int(ic), int(jc), int(k)] = float(v)
+
+        irr_flat = irr_map_3.ravel()
+        rot_flat = rot_map_3.reshape(-1, 3, 3)
+        A_idx = np.arange(3, dtype=np.int32)
+        B_idx = np.arange(3, dtype=np.int32)
+        C_idx = np.arange(3, dtype=np.int32)
+
+        i_at_sparse    = []
+        i_coord_sparse = []
+        jat_sparse     = []
+        j_coord_sparse = []
+        k_sparse       = []
+        value_sparse   = []
+
+        for canon_flat in np.unique(irr_flat):
+            i0, lj0, j0, lk0, k0 = np.unravel_index(
+                int(canon_flat), (n_atoms, n_replicas, n_atoms, n_replicas, n_atoms)
+            )
+            jat0 = lj0 * n_atoms + j0
+            if (i0, jat0) not in phi_irr:
+                continue
+
+            kat0 = (lk0 * n_atoms + k0) * 3
+            phi_333 = phi_irr[(i0, jat0)][:, :, kat0:kat0 + 3].copy()
+
+            equiv_idxs = np.where(irr_flat == canon_flat)[0]
+            i_all, lj_all, j_all, lk_all, k_all = np.unravel_index(
+                equiv_idxs, (n_atoms, n_replicas, n_atoms, n_replicas, n_atoms)
+            )
+            n_eq = len(equiv_idxs)
+
+            R_eq = rot_flat[equiv_idxs]
+            T1   = (R_eq @ phi_333.reshape(3, 9)).reshape(n_eq, 3, 3, 3)
+            T2   = (R_eq @ T1.transpose(0, 2, 1, 3).reshape(n_eq, 3, 9)
+                    ).reshape(n_eq, 3, 3, 3).transpose(0, 2, 1, 3)
+            T3   = (R_eq @ T2.transpose(0, 3, 1, 2).reshape(n_eq, 3, 9)
+                    ).reshape(n_eq, 3, 3, 3).transpose(0, 2, 3, 1)
+
+            jat_eq = (lj_all * n_atoms + j_all)
+            kat_eq = (lk_all * n_atoms + k_all) * 3
+
+            c_iat  = i_all[:, None, None, None]
+            c_ic   = A_idx[None, :, None, None]
+            c_jat  = jat_eq[:, None, None, None]
+            c_jc   = B_idx[None, None, :, None]
+            c_k    = kat_eq[:, None, None, None] + C_idx[None, None, None, :]
+
+            mask = T3 != 0.0
+            bc   = (n_eq, 3, 3, 3)
+            i_at_sparse.extend(np.broadcast_to(c_iat, bc)[mask].tolist())
+            i_coord_sparse.extend(np.broadcast_to(c_ic,  bc)[mask].tolist())
+            jat_sparse.extend(np.broadcast_to(c_jat, bc)[mask].tolist())
+            j_coord_sparse.extend(np.broadcast_to(c_jc,  bc)[mask].tolist())
+            k_sparse.extend(np.broadcast_to(c_k,    bc)[mask].tolist())
+            value_sparse.extend(T3[mask].tolist())
+
     coords = np.array([i_at_sparse, i_coord_sparse, jat_sparse, j_coord_sparse, k_sparse])
     shape = (n_atoms, 3, n_replicas * n_atoms, 3, n_replicas * n_atoms * 3)
     phifull = COO(coords, np.array(value_sparse), shape)
@@ -278,7 +640,7 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
     
 
 def _compute_iat_third(iat, atoms, replicated_atoms, third_order_delta, distance_threshold, is_verbose,
-                 calculator=None, scratch_dir=None, jat_flush_every=50):
+                 calculator=None, scratch_dir=None, jat_flush_every=50, allowed_jat=None):
     """Compute all third-order force constant terms for a single unit cell atom index.
 
     Parameters
@@ -295,6 +657,10 @@ def _compute_iat_third(iat, atoms, replicated_atoms, third_order_delta, distance
     jat_flush_every : int
         Number of jat iterations to accumulate (as compact numpy arrays) before
         flushing to disk. Only used when ``scratch_dir`` is set.
+    allowed_jat : set or None
+        When provided, only jat indices in this set are computed; all others are
+        skipped. Used by ``calculate_third`` when ``use_symmetry=True`` to restrict
+        computation to irreducible atom pairs.
     """
     if calculator is not None:
         replicated_atoms = replicated_atoms.copy()
@@ -312,7 +678,10 @@ def _compute_iat_third(iat, atoms, replicated_atoms, third_order_delta, distance
 
     for jat in range(n_replicas * n_atoms):
         is_computing = True
-        if distance_threshold is not None:
+        if allowed_jat is not None and jat not in allowed_jat:
+            is_computing = False
+            n_skipped += 9
+        if is_computing and distance_threshold is not None:
             dxij = replicated_atoms.get_distance(iat, jat, mic=True, vector=False)
             if dxij > distance_threshold:
                 is_computing = False

--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -168,13 +168,15 @@ def get_equivalent_ifc_indices(atoms, supercell, symprec=1e-5, order=2):
 
                 base_orig2 = i  * n_replicas * n_unit + j
                 base_new2  = ip * n_replicas * n_unit + jp
-                for l in range(n_replicas):
-                    f_orig = base_orig2 + l                * n_unit
-                    f_new  = base_new2  + int(l_j_new[l]) * n_unit
+                for lat in range(n_replicas):
+                    f_orig = base_orig2 + lat                * n_unit
+                    f_new  = base_new2  + int(l_j_new[lat]) * n_unit
                     r_o, r_n = _find(parent2, f_orig), _find(parent2, f_new)
                     if r_o != r_n:
-                        if r_o < r_n: parent2[r_n] = r_o
-                        else:         parent2[r_o] = r_n
+                        if r_o < r_n:
+                            parent2[r_n] = r_o
+                        else:
+                            parent2[r_o] = r_n
 
                 if order >= 3:
                     for k_atom in range(n_unit):
@@ -195,8 +197,10 @@ def get_equivalent_ifc_indices(atoms, supercell, symprec=1e-5, order=2):
                             r_o = _find(parent3, int(f_orig3[idx]))
                             r_n = _find(parent3, int(f_new3[idx]))
                             if r_o != r_n:
-                                if r_o < r_n: parent3[r_n] = r_o
-                                else:         parent3[r_o] = r_n
+                                if r_o < r_n:
+                                    parent3[r_n] = r_o
+                                else:
+                                    parent3[r_o] = r_n
 
     canonical2 = np.array([_find(parent2, f) for f in range(n_blocks_2)])
     irr_map_2  = canonical2.reshape(n_unit, n_replicas, n_unit)
@@ -648,7 +652,11 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
             c_jc   = B_idx[None, None, :, None]
             c_k    = kat_eq[:, None, None, None] + C_idx[None, None, None, :]
 
-            mask = T3 != 0.0
+            # Drop near-zero entries from the COO. FD output is rarely exactly
+            # zero; using `!= 0.0` would keep all the FD noise (~1e-7 for
+            # delta=1e-5) and inflate the sparse tensor. atol=1e-12 is well
+            # below physics-relevant scales (IFCs are 0.01-10).
+            mask = ~np.isclose(T3, 0.0, atol=1e-12)
             bc   = (n_eq, 3, 3, 3)
             i_at_sparse.extend(np.broadcast_to(c_iat, bc)[mask].tolist())
             i_coord_sparse.extend(np.broadcast_to(c_ic,  bc)[mask].tolist())

--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -75,12 +75,39 @@ def get_equivalent_ifc_indices(atoms, supercell, symprec=1e-5, order=2):
             "Try adjusting symprec or relaxing the structure."
         )
 
-    rotations    = dataset.rotations
-    translations = dataset.translations
+    rotations_full    = dataset.rotations
+    translations_full = dataset.translations
+
+    # Filter to spacegroup operations that the supercell shape can host.
+    # An integer rotation R acts on a supercell lattice vector as
+    #     g_new = R @ g + col_shift  (then mod-wrapped by the supercell shape)
+    # For this to be a bijection on the supercell mesh — the precondition
+    # for the equivalence-class union below to be valid — R must permute
+    # axes of the supercell only among themselves when their lengths
+    # differ. Concretely, on a diagonal supercell (nx, ny, nz) we require
+    # R[i, j] == 0 whenever supercell_shape[i] != supercell_shape[j].
+    # Cubic-shape supercells (N, N, N) keep all ops. Anisotropic shapes
+    # (e.g. slab (N, N, 1)) keep the in-plane subgroup. Non-diagonal
+    # supercells are caught by the caller (see calculate_second/third).
+    n_ops_full = len(rotations_full)
+    keep = np.ones(n_ops_full, dtype=bool)
+    for k in range(n_ops_full):
+        R = rotations_full[k]
+        for i in range(3):
+            for j in range(3):
+                if R[i, j] != 0 and supercell_shape[i] != supercell_shape[j]:
+                    keep[k] = False
+                    break
+            if not keep[k]:
+                break
+    rotations    = rotations_full[keep]
+    translations = translations_full[keep]
     n_ops = len(rotations)
+
     logging.info(
         f"Space group: {dataset.international} (#{dataset.number}), "
-        f"{n_ops} symmetry operations"
+        f"{n_ops_full} unit-cell ops, "
+        f"{n_ops} compatible with supercell shape {tuple(supercell_shape.tolist())}"
     )
 
     AT = lattice.T
@@ -239,6 +266,30 @@ def get_equivalent_ifc_indices(atoms, supercell, symprec=1e-5, order=2):
     return irr_map_2, rot_map_2, irr_map_3, rot_map_3
 
 
+def _diagonal_supercell_or_raise(atoms, replicated_atoms, tol=1e-6):
+    """Recover the diagonal supercell tuple from atoms / replicated_atoms.
+
+    Raises NotImplementedError when the supercell expansion is not diagonal.
+    The realspace symmetry path indexes lattice vectors as
+    ``ix * ny * nz + iy * nz + iz`` (C-order over a diagonal mesh) and
+    has no representation for a sheared supercell.
+    """
+    M = replicated_atoms.cell @ np.linalg.inv(atoms.cell)
+    M_int = np.round(M).astype(int)
+    if not np.allclose(M, M_int, atol=tol):
+        raise NotImplementedError(
+            "use_symmetry=True requires an integer supercell expansion. "
+            f"Got non-integer expansion matrix:\n{M}"
+        )
+    off_diag = M_int - np.diag(np.diag(M_int))
+    if np.any(off_diag != 0):
+        raise NotImplementedError(
+            "use_symmetry=True only supports diagonal supercell expansions. "
+            f"Got non-diagonal expansion matrix:\n{M_int}"
+        )
+    return tuple(np.diag(M_int))
+
+
 def list_of_replicas(atoms, replicated_atoms):
     n_atoms = atoms.positions.shape[0]
     n_replicas = int(replicated_atoms.positions.shape[0] / n_atoms)
@@ -302,8 +353,7 @@ def calculate_second(atoms, replicated_atoms, second_order_delta, is_verbose=Fal
         atoms_to_compute = list(range(n_atoms))
 
     if use_symmetry:
-        # Assumes diagonal supercell expansion; np.diag discards off-diagonal elements
-        supercell = tuple(np.diag(np.round(replicated_atoms.cell @ np.linalg.inv(atoms.cell)).astype(int)))
+        supercell = _diagonal_supercell_or_raise(atoms, replicated_atoms)
         irr_map_2, rot_map_2, _, _ = get_equivalent_ifc_indices(
             atoms, supercell, symprec=symprec, order=2
         )
@@ -489,8 +539,7 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
 
     # Build per-iat allowed_jat mapping from irreducible pair set when using symmetry
     if use_symmetry:
-        # Assumes diagonal supercell expansion; np.diag discards off-diagonal elements
-        supercell = tuple(np.diag(np.round(replicated_atoms.cell @ np.linalg.inv(atoms.cell)).astype(int)))
+        supercell = _diagonal_supercell_or_raise(atoms, replicated_atoms)
         _, _, irr_map_3, rot_map_3 = get_equivalent_ifc_indices(
             atoms, supercell, symprec=symprec, order=3
         )

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -346,10 +346,12 @@ class SecondOrder(ForceConstant):
             If True, keep scratch files after successful assembly.
             Default: False
         use_symmetry : bool, optional
-            If True, will use crystal spacegroup to reduce number of pairs
-            calculated by the method. Do not use while reading/writing with 
-            scratch_dir (leave scratch_dir=False), will throw an error if
-            scratch_dir is not None.
+            If True, use the crystal spacegroup to reduce the number of
+            atoms displaced by the FD method. Only spacegroup operations
+            compatible with the supercell shape are used (e.g. an in-plane
+            subgroup for slab supercells). Requires a diagonal integer
+            supercell expansion. Not compatible with ``scratch_dir`` —
+            pass ``scratch_dir=None`` (the default) when enabling.
             Default: False
         symprec : float, optional
             precision for symmetry using spglib.

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -413,7 +413,6 @@ class SecondOrder(ForceConstant):
                 scratch_dir=scratch_dir,
                 keep_scratch=keep_scratch,
                 use_symmetry=use_symmetry,
-                supercell=self.supercell,
                 symprec=symprec,
             )
         if self.is_acoustic_sum:

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -285,7 +285,7 @@ class SecondOrder(ForceConstant):
             return self._dynmat
 
     def calculate(self, calculator=None, delta_shift=1e-3, is_storing=True, is_verbose=False, n_workers=1,
-                  scratch_dir=None, keep_scratch=False):
+                  scratch_dir=None, keep_scratch=False, use_symmetry=False, symprec=1e-5):
         """
         Calculate second-order force constants with finite differences.
 
@@ -383,6 +383,8 @@ class SecondOrder(ForceConstant):
                     calculator=worker_calculator,
                     scratch_dir=scratch_dir,
                     keep_scratch=keep_scratch,
+                    use_symmetry=use_symmetry,
+                    symprec=symprec,
                 )
                 self.save("second")
                 if calculator is not None:
@@ -401,6 +403,9 @@ class SecondOrder(ForceConstant):
                 calculator=worker_calculator,
                 scratch_dir=scratch_dir,
                 keep_scratch=keep_scratch,
+                use_symmetry=use_symmetry,
+                supercell=self.supercell,
+                symprec=symprec,
             )
         if self.is_acoustic_sum:
             self.value = acoustic_sum_rule(self.value)

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -372,7 +372,10 @@ class SecondOrder(ForceConstant):
             worker_calculator = calculator
         # Auto-resolve the default scratch directory only for parallel runs;
         # serial stays in memory to avoid creating unexpected directories.
-        if scratch_dir is None and self.folder and is_parallel(n_workers):
+        # use_symmetry is incompatible with scratch_dir (calculate_second
+        # raises ValueError on the combo), so don't auto-assign in that case.
+        if (scratch_dir is None and self.folder and is_parallel(n_workers)
+                and not use_symmetry):
             scratch_dir = os.path.join(self.folder, 'second_order')
         elif scratch_dir == '':
             scratch_dir = None

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -340,8 +340,11 @@ class SecondOrder(ForceConstant):
             for recovery of interrupted calculations. Pass an explicit path to
             override. Pass an empty string ``''`` to disable scratch files and
             fall back to in-memory accumulation.
-            Default: ``{folder}/second_order`` when ``self.folder`` is set and
-            ``n_workers > 1``
+            Default: ``{folder}/second_order`` when ``self.folder`` is set,
+            ``n_workers > 1``, and ``use_symmetry=False``. With
+            ``use_symmetry=True`` the auto-default is suppressed (the two
+            modes are mutually incompatible — see the ``use_symmetry``
+            docstring below).
         keep_scratch : bool, optional
             If True, keep scratch files after successful assembly.
             Default: False

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -345,6 +345,15 @@ class SecondOrder(ForceConstant):
         keep_scratch : bool, optional
             If True, keep scratch files after successful assembly.
             Default: False
+        use_symmetry : bool, optional
+            If True, will use crystal spacegroup to reduce number of pairs
+            calculated by the method. Do not use while reading/writing with 
+            scratch_dir (leave scratch_dir=False), will throw an error if
+            scratch_dir is not None.
+            Default: False
+        symprec : float, optional
+            precision for symmetry using spglib.
+            Default: 1e-5
         """
         if is_parallel(n_workers):
             validate_parallel_calculator(calculator, method='SecondOrder.calculate')

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -322,10 +322,13 @@ class ThirdOrder(ForceConstant):
             Number of jat iterations each worker buffers before flushing to disk.
             Smaller values use less memory at the cost of more I/O. Default 50.
         use_symmetry : bool, optional
-            If True, will use crystal spacegroup to reduce number of pairs
-            calculated by the method. Do not use while reading/writing with 
-            scratch_dir (leave scratch_dir=False), will throw an error if
-            scratch_dir is not None.
+            If True, use the crystal spacegroup to reduce the number of
+            atom pairs (i, jat) computed by the FD method. Only spacegroup
+            operations compatible with the supercell shape are used (e.g.
+            an in-plane subgroup for slab supercells). Requires a
+            diagonal integer supercell expansion. Not compatible with
+            ``scratch_dir`` — pass ``scratch_dir=None`` (the default)
+            when enabling.
             Default: False
         symprec : float, optional
             precision for symmetry using spglib.

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -321,6 +321,15 @@ class ThirdOrder(ForceConstant):
         jat_flush_every : int
             Number of jat iterations each worker buffers before flushing to disk.
             Smaller values use less memory at the cost of more I/O. Default 50.
+        use_symmetry : bool, optional
+            If True, will use crystal spacegroup to reduce number of pairs
+            calculated by the method. Do not use while reading/writing with 
+            scratch_dir (leave scratch_dir=False), will throw an error if
+            scratch_dir is not None.
+            Default: False
+        symprec : float, optional
+            precision for symmetry using spglib.
+            Default: 1e-5
         """
         if is_parallel(n_workers):
             validate_parallel_calculator(calculator, method='ThirdOrder.calculate')

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -349,7 +349,10 @@ class ThirdOrder(ForceConstant):
             worker_calculator = calculator
         # Auto-resolve the default scratch directory only for parallel runs;
         # serial stays in memory to avoid creating unexpected directories.
-        if scratch_dir is None and self.folder and is_parallel(n_workers):
+        # use_symmetry is incompatible with scratch_dir (calculate_third
+        # raises ValueError on the combo), so don't auto-assign in that case.
+        if (scratch_dir is None and self.folder and is_parallel(n_workers)
+                and not use_symmetry):
             scratch_dir = os.path.join(self.folder, 'third_order')
         elif scratch_dir == '':
             scratch_dir = None

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -314,7 +314,11 @@ class ThirdOrder(ForceConstant):
             peak memory low. Pass an explicit path to override. Pass an
             empty string ``''`` to disable scratch files and fall back to
             in-memory accumulation.
-            Default: ``{folder}/third_order`` when ``self.folder`` is set
+            Default: ``{folder}/third_order`` when ``self.folder`` is set,
+            ``n_workers > 1``, and ``use_symmetry=False``. With
+            ``use_symmetry=True`` the auto-default is suppressed (the two
+            modes are mutually incompatible — see the ``use_symmetry``
+            docstring below).
         keep_scratch : bool
             If True, scratch files are kept after assembly.
             Default: False

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -384,7 +384,6 @@ class ThirdOrder(ForceConstant):
                                          keep_scratch=keep_scratch,
                                          jat_flush_every=jat_flush_every,
                                          use_symmetry=use_symmetry,
-                                         supercell=self.supercell,
                                          symprec=symprec)
             if is_storing:
                 self.save('third')

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -264,7 +264,7 @@ class ThirdOrder(ForceConstant):
 
 
     def calculate(self, calculator=None, delta_shift=1e-4, distance_threshold=None, is_storing=True, is_verbose=False,
-                  n_workers=1, scratch_dir=None, keep_scratch=False, jat_flush_every=50):
+                  n_workers=1, scratch_dir=None, keep_scratch=False, jat_flush_every=50, use_symmetry=False, symprec=1e-5):
         """Calculate the third order force constants.
 
         This is the method typically reached through ``fc.third.calculate(...)``.
@@ -356,7 +356,9 @@ class ThirdOrder(ForceConstant):
                                              calculator=worker_calculator,
                                              scratch_dir=scratch_dir,
                                              keep_scratch=keep_scratch,
-                                             jat_flush_every=jat_flush_every)
+                                             jat_flush_every=jat_flush_every,
+                                             use_symmetry=use_symmetry,
+                                             symprec=symprec)
                 self.save('third')
                 ase.io.write(self.folder + '/' + REPLICATED_ATOMS_THIRD_FILE, self.replicated_atoms, 'extxyz')
             else:
@@ -371,7 +373,10 @@ class ThirdOrder(ForceConstant):
                                          calculator=worker_calculator,
                                          scratch_dir=scratch_dir,
                                          keep_scratch=keep_scratch,
-                                         jat_flush_every=jat_flush_every)
+                                         jat_flush_every=jat_flush_every,
+                                         use_symmetry=use_symmetry,
+                                         supercell=self.supercell,
+                                         symprec=symprec)
             if is_storing:
                 self.save('third')
                 ase.io.write(self.folder + '/' + REPLICATED_ATOMS_THIRD_FILE, self.replicated_atoms, 'extxyz')

--- a/kaldo/tests/test_displacement_symmetry.py
+++ b/kaldo/tests/test_displacement_symmetry.py
@@ -1,0 +1,104 @@
+"""
+Tests for the realspace symmetry reduction in calculate_second/calculate_third.
+
+For correct implementation, the use_symmetry=True path must produce force
+constants numerically equal to the use_symmetry=False baseline (modulo
+floating-point noise) for any supercell shape the symmetry path supports.
+
+System: Cu FCC conventional cell (4 atoms) with ASE's built-in EMT calculator.
+Cu is chosen because EMT supports it, the conventional cell is high-symmetry
+(Oh point group), and the small atom count keeps the test fast.
+"""
+import numpy as np
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from kaldo.controllers.displacement import calculate_second, calculate_third
+
+
+def _cu_atoms(supercell):
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    replicated_atoms = atoms.repeat(supercell)
+    replicated_atoms.calc = EMT()
+    return atoms, replicated_atoms
+
+
+# Cubic and slab supercells; the slab case (2,1,1) is the regression case for
+# the supercell-incompatible-op bug — most spacegroup ops swap axes and must
+# be filtered out, leaving only the in-plane subgroup.
+SUPERCELLS = [(2, 2, 2), (2, 1, 1), (3, 1, 1)]
+
+
+@pytest.mark.parametrize("supercell", SUPERCELLS)
+def test_calculate_second_use_symmetry_matches_baseline(supercell):
+    atoms, rep = _cu_atoms(supercell)
+
+    baseline = calculate_second(
+        atoms, rep, second_order_delta=1e-5, n_workers=1, calculator=EMT(),
+    )
+    sym = calculate_second(
+        atoms, rep, second_order_delta=1e-5, n_workers=1, calculator=EMT(),
+        use_symmetry=True,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(sym), np.asarray(baseline),
+        rtol=1e-7, atol=1e-9,
+        err_msg=f"Second-order use_symmetry result mismatch on supercell={supercell}",
+    )
+
+
+@pytest.mark.parametrize("supercell", SUPERCELLS)
+def test_calculate_third_use_symmetry_matches_baseline(supercell):
+    atoms, rep = _cu_atoms(supercell)
+
+    baseline = calculate_third(
+        atoms, rep, third_order_delta=1e-5, n_workers=1, calculator=EMT(),
+    )
+    sym = calculate_third(
+        atoms, rep, third_order_delta=1e-5, n_workers=1, calculator=EMT(),
+        use_symmetry=True,
+    )
+
+    base_dense = baseline.todense() if hasattr(baseline, 'todense') else np.asarray(baseline)
+    sym_dense  = sym.todense()      if hasattr(sym, 'todense')      else np.asarray(sym)
+
+    # FD-noise floor for third-order with delta=1e-5 is ~1e-4 absolute on
+    # IFC values of order 1-10. The symmetry path computes the canonical
+    # block via FD on different atom displacements than the baseline does
+    # for the rotated-equivalent block, so the two computations don't
+    # agree to machine precision even when the rotation algebra is exact.
+    # atol=1e-3 covers this; rtol=1e-6 keeps physics-relevant entries tight.
+    np.testing.assert_allclose(
+        sym_dense, base_dense,
+        rtol=1e-6, atol=1e-3,
+        err_msg=f"Third-order use_symmetry result mismatch on supercell={supercell}",
+    )
+
+
+def test_use_symmetry_rejects_non_diagonal_supercell():
+    """A non-diagonal (sheared) supercell must raise NotImplementedError
+    rather than silently producing wrong results."""
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    # Build a non-diagonal supercell by manually constructing the cell.
+    rep = atoms.repeat((2, 2, 2))
+    sheared_cell = rep.cell.array.copy()
+    sheared_cell[0, 1] = 0.5  # introduce a tiny shear
+    rep.set_cell(sheared_cell, scale_atoms=False)
+    rep.calc = EMT()
+
+    with pytest.raises(NotImplementedError, match="diagonal|integer"):
+        calculate_second(
+            atoms, rep, second_order_delta=1e-5, n_workers=1, calculator=EMT(),
+            use_symmetry=True,
+        )
+
+
+def test_use_symmetry_rejects_scratch_dir(tmp_path):
+    """use_symmetry=True must not silently combine with scratch_dir."""
+    atoms, rep = _cu_atoms((2, 2, 2))
+    with pytest.raises(ValueError, match="scratch_dir"):
+        calculate_second(
+            atoms, rep, second_order_delta=1e-5, n_workers=1, calculator=EMT(),
+            use_symmetry=True, scratch_dir=str(tmp_path),
+        )

--- a/kaldo/tests/test_displacement_symmetry.py
+++ b/kaldo/tests/test_displacement_symmetry.py
@@ -102,3 +102,24 @@ def test_use_symmetry_rejects_scratch_dir(tmp_path):
             atoms, rep, second_order_delta=1e-5, n_workers=1, calculator=EMT(),
             use_symmetry=True, scratch_dir=str(tmp_path),
         )
+
+
+def test_use_symmetry_with_parallel_via_observable(tmp_path):
+    """SecondOrder.calculate / ThirdOrder.calculate with use_symmetry=True
+    AND n_workers>1 must NOT auto-fill scratch_dir from self.folder.
+    Otherwise calculate_second/third would reject the combination and
+    the user's parallel symmetry call would always fail.
+    Regression test for CodeRabbit finding on PR #253."""
+    import shutil
+    from kaldo.forceconstants import ForceConstants
+
+    atoms = bulk("Cu", "fcc", a=3.61, cubic=True)
+
+    folder = str(tmp_path / "fc_sym_parallel")
+    shutil.rmtree(folder, ignore_errors=True)
+
+    fc = ForceConstants(atoms=atoms, supercell=(2, 2, 2), folder=folder)
+    # SecondOrder.calculate with use_symmetry=True + n_workers=2 must succeed
+    fc.second.calculate(calculator=EMT, n_workers=2, use_symmetry=True)
+    # ThirdOrder.calculate with use_symmetry=True + n_workers=2 must succeed
+    fc.third.calculate(calculator=EMT, n_workers=2, use_symmetry=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ scipy>=1.11.1
 ase>=3.22.1
 sparse>=0.15
 seekpath>=1.8
+spglib>=2.0
 tensorflow>=2.13
 opt_einsum>=2.3
 scikit-learn>=1.3.0


### PR DESCRIPTION
This branch updates the realspace symmetries implemented in the prior PR to be compatible with the newly updated parallelization scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Symmetry-aware force-constant workflow: compute irreducible blocks and reconstruct full 2nd‑ and 3rd‑order tensors.
  * New options to enable symmetry mode and control symmetry tolerance.

* **Bug Fixes / Behavior**
  * Symmetry mode disallows non‑diagonal supercells and rejects use with temporary scratch storage; parallel runs skip auto scratch assignment when symmetry is enabled.

* **Tests**
  * Added tests validating symmetry results, error cases, and parallel symmetry runs.

* **Chores**
  * Added spglib dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->