### PR TITLE
Add advisory flake8 lint job to CircleCI; fix CodeRabbit tone_instructions length

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,17 @@ jobs:
           name: Test
       - codecov/upload:
           file: ./coverage.xml
+  lint:
+    docker:
+      - image: "gbarbalinardo/kaldo:amd"
+    steps:
+      - checkout
+      - run:
+          name: Install flake8
+          command: pip install --quiet flake8
+      - run:
+          name: Run flake8 (advisory; reads max-line-length from setup.cfg)
+          command: python -m flake8 kaldo/ --count --statistics --exit-zero
   docs-build:
     docker:
       - image: "gbarbalinardo/kaldo_docs:amd"
@@ -54,6 +65,7 @@ workflows:
   main:
     jobs:
       - build-and-test
+      - lint
       - docs-build
       - docs-deploy:
           requires:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,10 +4,9 @@
 language: en-US
 early_access: false
 tone_instructions: >
-  Be concise and technical. This is a scientific Python library for thermal
-  transport (BTE/QHGK). Prioritize correctness of physics and numerics, dtype
-  consistency, GPU/CPU dispatch, and TensorFlow vs NumPy boundaries. Avoid
-  cosmetic nitpicks; respect the project's flake8/yapf line length of 119.
+  Concise and technical. Scientific Python library for thermal transport.
+  Prioritize numerical correctness, dtype, GPU/CPU dispatch. Avoid cosmetic
+  nitpicks; respect flake8/yapf line length of 119.
 
 reviews:
   profile: chill


### PR DESCRIPTION
Two small AI-readiness follow-ups:

1. CircleCI: adds a lint job that runs flake8 kaldo/ in parallel with build-and-test, using --exit-zero so it never blocks CI. Reports counts and per-rule statistics so we have visibility on style drift while we decide on a cleanup approach. Reuses the existing gbarbalinardo/kaldo:amd docker image and reads max-line-length=119 from setup.cfg. Current baseline locally is ~1000 violations (mostly W291/W293 whitespace and E501 long lines).

2. .coderabbit.yaml: trims tone_instructions from ~340 to ~196 chars to fit CodeRabbit's 250-char cap (the prior config failed to parse on this PR with "Validation error: String must contain at most 250 character(s) at tone_instructions"). Substantive numerical-review guidance still lives in path_instructions, which has no such cap.

Future once we want to enforce lint: drop --exit-zero, or do a one-shot yapf/auto-fix PR first to get the count to zero.