### PR TITLE
Trim CodeRabbit tone_instructions to fit 250-char cap

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,10 +4,9 @@
 language: en-US
 early_access: false
 tone_instructions: >
-  Be concise and technical. This is a scientific Python library for thermal
-  transport (BTE/QHGK). Prioritize correctness of physics and numerics, dtype
-  consistency, GPU/CPU dispatch, and TensorFlow vs NumPy boundaries. Avoid
-  cosmetic nitpicks; respect the project's flake8/yapf line length of 119.
+  Concise and technical. Scientific Python library for thermal transport.
+  Prioritize numerical correctness, dtype, GPU/CPU dispatch. Avoid cosmetic
+  nitpicks; respect flake8/yapf line length of 119.
 
 reviews:
   profile: chill


### PR DESCRIPTION
CodeRabbit rejected the prior config on PR #255 with: "Validation error: String must contain at most 250 character(s) at tone_instructions". The substantive numerical-review guidance (float ==, dtype, einsum, TF top-level imports) lives in path_instructions, which has no such cap, so the tone field can stay short and focus on style of feedback. New length is 196 chars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration to enhance consistency and focus on technical accuracy in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->