### PR TITLE
Disable CodeRabbit in_progress_fortune (kill the ASCII cow)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,7 @@ reviews:
   request_changes_workflow: false
   high_level_summary: true
   poem: false
+  in_progress_fortune: false
   review_status: true
   collapse_walkthrough: true
   auto_review:


### PR DESCRIPTION
The 'progress' comment CodeRabbit posts while a review is queued includes a randomized one-liner inside an ASCII cow box (e.g. 'Your function signature is a cry for help.'). It's decorative noise that crowds out actual review content.

Setting reviews.in_progress_fortune to false keeps the progress comment itself (so we still see review status) but drops the cow + tagline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings for code review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->