### PR TITLE
Lower CodeRabbit docstring threshold to 60%; ignore docs/superpowers/

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -55,6 +55,10 @@ reviews:
         chosen for the physics, not whatever makes them pass. Use tmp_path for
         any filesystem writes. Don't mock the filesystem to substitute for
         reference data files in sibling directories (si-crystal/, mgo/, etc.).
+  pre_merge_checks:
+    docstrings:
+      mode: warning
+      threshold: 60
   tools:
     ruff:
       enabled: false

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ docs/docsource/API
 
 # Claude Code per-developer settings (allowlist overrides, etc.)
 .claude/settings.local.json
+
+# Local scratch / superpowers workspace under docs (never tracked)
+docs/superpowers/


### PR DESCRIPTION
Two small follow-ups:

1. .coderabbit.yaml: lower docstring coverage threshold from the default 80% to 60%. PR #249 hit 63.64% and got flagged; 60% is closer to current reality and gives PRs a target without making the warning a constant noise source. Mode stays 'warning' so it never blocks merges; raising the threshold later is one keystroke.

2. .gitignore: ignore docs/superpowers/. Local scratch / experimentation area; never intended for tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-merge docstring linting (warning mode, threshold 60) to improve documentation QA.
  * Updated ignore rules to exclude local developer tool settings and a local docs/scratch workspace from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->