### PR TITLE
CI fixes: tests, ballistic early return, drop gc.collect, storage shape

### DIFF
--- a/kaldo/conductivity.py
+++ b/kaldo/conductivity.py
@@ -9,7 +9,6 @@ from kaldo.controllers.dirac_kernel import lorentz_delta, gaussian_delta, triang
 from kaldo.storable import lazy_property, Storable
 import kaldo.observables.harmonic_with_q_temp as hwqwt
 from kaldo.helpers.logger import get_logger, log_size
-import gc
 
 logging = get_logger()
 
@@ -428,8 +427,6 @@ class Conductivity(Storable):
                     diffusivity_with_axis[k_index, :, alpha, beta] = np.sum(diffusivity, axis=-1).real
                 del sij_left, sij_right, diffusivity
             del phonon, heat_capacity_2d
-            if k_index % 10 == 0:
-                gc.collect()
 
         diffusivity = 1 / 3 * 1 / 100 * contract('knaa->kn', diffusivity_with_axis)
         return conductivity_per_mode.reshape((self.n_phonons, 3, 3)) * 1e22, diffusivity
@@ -462,13 +459,11 @@ class Conductivity(Storable):
 
             if finite_length_method == 'ms' and length is not None and length[alpha]:
                 gamma += 2 * np.abs(velocity[:, alpha]) / length[alpha]
-            gc.collect()
 
             np.add(scattering_matrix, np.diag(gamma[physical_mode]), out=scattering_matrix)
             scattering_inverse = np.linalg.inv(scattering_matrix)
             lambd[physical_mode, alpha] = scattering_inverse.dot(velocity[physical_mode, alpha])
             del scattering_matrix, scattering_inverse, gamma
-            gc.collect()
 
             if finite_length_method == 'ballistic' and (self.length[alpha] is not None) and (self.length[alpha] != 0):
                 velocity_alpha = velocity[physical_mode, alpha]
@@ -477,7 +472,6 @@ class Conductivity(Storable):
                 gamma_inv[nonzero_velocity] = length[alpha] / (2 * np.abs(velocity_alpha[nonzero_velocity]))
                 lambd[physical_mode, alpha] = np.diag(gamma_inv).dot(velocity_alpha)
                 del gamma_inv, nonzero_velocity, velocity_alpha
-                gc.collect()
 
         return lambd
 

--- a/kaldo/conductivity.py
+++ b/kaldo/conductivity.py
@@ -448,6 +448,16 @@ class Conductivity(Storable):
         velocity = phonons.velocity.real.reshape((phonons.n_phonons, 3))
         lambd = np.zeros_like(velocity, dtype=np.float32)  # Use float32 if precision allows
 
+        if finite_length_method == 'ballistic':
+            for alpha in range(3):
+                if (length[alpha] is not None) and (length[alpha] != 0):
+                    velocity_alpha = velocity[physical_mode, alpha]
+                    gamma_inv = np.zeros_like(velocity_alpha)
+                    nonzero_velocity = velocity_alpha != 0
+                    gamma_inv[nonzero_velocity] = length[alpha] / (2 * np.abs(velocity_alpha[nonzero_velocity]))
+                    lambd[physical_mode, alpha] = np.diag(gamma_inv).dot(velocity_alpha)
+            return lambd
+
         for alpha in range(3):
             scattering_matrix = self.calculate_scattering_matrix(
                 is_including_diagonal=False,
@@ -464,14 +474,6 @@ class Conductivity(Storable):
             scattering_inverse = np.linalg.inv(scattering_matrix)
             lambd[physical_mode, alpha] = scattering_inverse.dot(velocity[physical_mode, alpha])
             del scattering_matrix, scattering_inverse, gamma
-
-            if finite_length_method == 'ballistic' and (self.length[alpha] is not None) and (self.length[alpha] != 0):
-                velocity_alpha = velocity[physical_mode, alpha]
-                gamma_inv = np.zeros_like(velocity_alpha)
-                nonzero_velocity = velocity_alpha != 0
-                gamma_inv[nonzero_velocity] = length[alpha] / (2 * np.abs(velocity_alpha[nonzero_velocity]))
-                lambd[physical_mode, alpha] = np.diag(gamma_inv).dot(velocity_alpha)
-                del gamma_inv, nonzero_velocity, velocity_alpha
 
         return lambd
 

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -369,13 +369,7 @@ class Phonons(Storable):
         if property_name == 'physical_mode':
             loaded = np.loadtxt(name + '.dat', skiprows=1)
             return np.round(loaded, 0).astype(bool)
-        elif property_name == 'velocity':
-            loaded = []
-            for alpha in range(3):
-                loaded.append(np.loadtxt(name + '_' + str(alpha) + '.dat', skiprows=1))
-            return np.array(loaded).transpose(1, 2, 0)
         else:
-            # Use default implementation for other properties
             return super()._load_formatted_property(property_name, name)
     
     def _save_formatted_property(self, property_name, name, data):

--- a/kaldo/storable.py
+++ b/kaldo/storable.py
@@ -58,29 +58,43 @@ class Storable:
         else:
             raise ValueError(f'Storage format {format} not implemented')
     
+    @staticmethod
+    def _read_formatted_file(filename):
+        """Read a single .dat file, returning (data, shape) with dtype inferred from header."""
+        with open(filename, 'r') as f:
+            header = f.readline().strip()
+        dtype = complex if 'complex' in header.lower() else float
+        data = np.loadtxt(filename, skiprows=1, dtype=dtype)
+        shape = None
+        if '(' in header and ')' in header:
+            shape_str = header[header.find('(') + 1:header.find(')')]
+            try:
+                shape = tuple(int(x.strip()) for x in shape_str.split(',') if x.strip())
+            except ValueError:
+                pass
+        return data, shape
+
     def _load_formatted_property(self, property_name, name):
+        """Load a property from formatted .dat files.
+
+        Handles both single files and split files (3D arrays with spatial
+        last dimension stored as name_0.dat, name_1.dat, name_2.dat).
+        Restores original array shape from the header written by _save_formatted_property.
         """
-        Load a property from formatted files. Override in subclasses for 
-        property-specific formatted loading.
-        
-        Parameters
-        ----------
-        property_name : str
-            Name of the property
-        name : str
-            Full file path without extension
-            
-        Returns
-        -------
-        loaded_data : any
-            The loaded property data
-        """
-        # Default: single file with float dtype
-        if property_name == 'diffusivity':
-            dt = complex
-        else:
-            dt = float
-        return np.loadtxt(name + '.dat', skiprows=1, dtype=dt)
+        # Split files (3D array with last dim = 3)
+        if os.path.exists(name + '_0.dat'):
+            slices = [self._read_formatted_file(f'{name}_{a}.dat') for a in range(3)]
+            data = np.array([s[0] for s in slices])
+            shape = slices[0][1]
+            if shape is not None and np.prod(shape) == data[0].size:
+                return np.stack([d.reshape(shape) for d in data], axis=-1)
+            return np.moveaxis(data, 0, -1)
+
+        # Single file
+        data, shape = self._read_formatted_file(name + '.dat')
+        if shape is not None and np.prod(shape) == data.size:
+            data = data.reshape(shape)
+        return data
     
     def _save_property(self, property_name, folder, data, format='formatted'):
         """
@@ -124,9 +138,9 @@ class Storable:
     
     def _save_formatted_property(self, property_name, name, data):
         """
-        Save a property to formatted files. Override in subclasses for 
-        property-specific formatted saving.
-        
+        Save a property to formatted files. Handles multi-dimensional arrays
+        by splitting along the last dimension when it equals 3 (spatial coords).
+
         Parameters
         ----------
         property_name : str
@@ -136,9 +150,24 @@ class Storable:
         data : any
             The property data to save
         """
-        # Default: single file with scientific notation
         fmt = '%.18e'
-        np.savetxt(name + '.dat', data, fmt=fmt, header=str(data.shape))
+
+        # Handle 3D+ arrays with last dimension = 3 (spatial coordinates)
+        if data.ndim >= 3 and data.shape[-1] == 3:
+            for alpha in range(3):
+                slice_data = data[..., alpha]
+                # Flatten if still > 2D after slicing
+                if slice_data.ndim > 2:
+                    slice_data = slice_data.reshape(-1, slice_data.shape[-1]) if slice_data.ndim > 1 else slice_data.flatten()
+                np.savetxt(name + '_' + str(alpha) + '.dat', slice_data, fmt=fmt,
+                          header=str(data[..., 0].shape))
+        elif data.ndim > 2:
+            # Generic fallback: flatten to 2D, store original shape in header
+            flat_data = data.reshape(-1, data.shape[-1]) if data.shape[-1] > 1 else data.flatten()
+            np.savetxt(name + '.dat', flat_data, fmt=fmt, header=str(data.shape))
+        else:
+            # Default: 1D or 2D array
+            np.savetxt(name + '.dat', data, fmt=fmt, header=str(data.shape))
     
     def get_folder_from_label(self, label='', base_folder=None):
         """

--- a/kaldo/storable.py
+++ b/kaldo/storable.py
@@ -165,6 +165,11 @@ class Storable:
             # Generic fallback: flatten to 2D, store original shape in header
             flat_data = data.reshape(-1, data.shape[-1]) if data.shape[-1] > 1 else data.flatten()
             np.savetxt(name + '.dat', flat_data, fmt=fmt, header=str(data.shape))
+        elif np.iscomplexobj(data):
+            # Complex arrays (e.g. diffusivity) need numpy's default (real+imagj)
+            # format; a float format cannot represent them. The 'complex' header
+            # tag tells _read_formatted_file to load them back as complex.
+            np.savetxt(name + '.dat', data, header='complex ' + str(data.shape))
         else:
             # Default: 1D or 2D array
             np.savetxt(name + '.dat', data, fmt=fmt, header=str(data.shape))

--- a/kaldo/storable.py
+++ b/kaldo/storable.py
@@ -227,13 +227,6 @@ class Storable:
 
 
 
-def parse_pair(txt):
-    return complex(txt.strip("()"))
-
-
-
-
-
 def lazy_property(label: str = '', format: Optional[str] = None) -> Callable[[Callable], property]:
     """
     Decorator for lazy evaluation of properties with storage support.

--- a/kaldo/tests/test_crystal_qe_vasp.py
+++ b/kaldo/tests/test_crystal_qe_vasp.py
@@ -45,9 +45,41 @@ def test_lagacy_format():
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    """QHGK conductivity with constant diffusivity_bandwidth.
+
+    Why a constant bandwidth: with the default
+    ``diffusivity_bandwidth=None``, the QHGK calculation uses
+    ``phonons.bandwidth / 2`` per mode, which includes
+    ``isotopic_bandwidth`` when ``include_isotopes=True``. The
+    isotopic bandwidth involves the squared overlap
+    ``|⟨e_q'μ' | e_qμ⟩|²``, which is NOT invariant under unitary
+    rotations of the eigenvector basis within a degenerate subspace.
+    Different LAPACK implementations (x86 vs arm64) return different
+    bases — all valid solutions — so per-mode isotopic bandwidth (and
+    therefore the per-mode diffusivity_bandwidth, and therefore the
+    per-mode QHGK conductivity contribution) varies platform-by-platform.
+
+    Setting ``diffusivity_bandwidth=1.0`` (THz, constant) decouples
+    the conductivity from this gauge-dependent per-mode quantity. The
+    SUM of conductivity contributions over a degenerate group remains
+    basis-invariant (trace of the Onsager-style scattering operator
+    in the degenerate subspace), but the per-mode breakdown does not.
+
+    Same gauge-vs-observable pattern as ``test_iso_bw`` and the
+    broadening-vs-symmetry trade-off documented for ``use_q_symmetry``
+    (PR #253): replace the basis-dependent regularization with a
+    constant to get a reproducible reference value.
+
+    Trade-off: this test no longer exercises the default per-mode
+    bandwidth path. That path's correctness is exercised by
+    ``test_qhgk_conductivity`` in ``test_crystal.py`` on a
+    centrosymmetric crystal where the degeneracies are sparse enough
+    that the basis dependence stays below the test tolerance.
+    """
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 3, significant=2)
+    np.testing.assert_approx_equal(cond, 2.2, significant=2)
 
 
 def test_rta_conductivity(phonons):

--- a/kaldo/tests/test_ge_qe_crystal.py
+++ b/kaldo/tests/test_ge_qe_crystal.py
@@ -36,5 +36,43 @@ def test_frequency(phonons):
 
 
 def test_iso_bw(phonons):
-    freq = phonons.isotopic_bandwidth.flatten()
-    np.testing.assert_approx_equal(freq[3], 7.85 * 1e-3, significant=3)
+    """Isotopic bandwidth at the Γ-point optical-mode triplet.
+
+    Physics: Ge diamond has a 3-fold degenerate optical phonon triplet at
+    the Γ point (modes 3, 4, 5). Within any degenerate subspace the
+    eigenvectors are defined only up to a unitary rotation U, and
+    different LAPACK implementations (x86 vs arm64, vendor BLAS vs MKL)
+    return different bases — all equally valid solutions of the
+    eigenvalue problem.
+
+    The Tamura formula for isotopic scattering involves the squared
+    overlap |⟨e_q'μ' | e_qμ⟩|², which is NOT invariant under a basis
+    rotation within the degenerate subspace. Concretely, if
+    ẽ_3 = U_33 e_3 + U_34 e_4 + U_35 e_5, then
+    |⟨e_μ' | ẽ_3⟩|² = |U_33 A + U_34 B + U_35 C|², which is not equal
+    to |A|² alone unless U is the identity.
+
+    The SUM (or mean) of Γ_iso(μ) over the degenerate group IS
+    basis-invariant: cross-terms cancel by unitarity (∑_μ U*_μν U_μν' =
+    δ_νν'), so ∑_μ |∑_ν U_μν A_ν|² = ∑_ν |A_ν|². This is the trace of
+    the scattering operator restricted to the degenerate subspace — a
+    true physical observable.
+
+    This test therefore asserts the basis-invariant mean over the
+    triplet, which is the trace of the scattering operator restricted
+    to the degenerate subspace divided by the dimension. Asserting an
+    individual triplet member would be platform-dependent.
+
+    The per-mode SPREAD within the triplet (max - min) is itself
+    basis-dependent and varies platform-by-platform — we deliberately
+    do NOT bound it.
+
+    Same gauge-vs-observable distinction as the broadening-vs-symmetry
+    issue documented for ``use_q_symmetry`` (PR #253): an operation
+    (rotation, broadening function evaluation) that doesn't commute
+    with the gauge produces basis-dependent per-mode quantities; the
+    invariant lives at the trace level.
+    """
+    iso_bw = phonons.isotopic_bandwidth.flatten()
+    triplet_mean = np.mean(iso_bw[3:6])
+    np.testing.assert_approx_equal(triplet_mean, 7.75 * 1e-3, significant=3)

--- a/kaldo/tests/test_lazy_loading.py
+++ b/kaldo/tests/test_lazy_loading.py
@@ -639,3 +639,27 @@ def test_get_folder_from_label_with_q_point_and_temperature():
 
     # Critical: different temperatures must produce different paths
     assert folder_300 != folder_500
+
+
+def _roundtrip_formatted(data, tmp_path):
+    """Save then load `data` through the real Storable formatted methods."""
+    instance = Storable()
+    folder = str(tmp_path)
+    instance._save_formatted_property('prop', folder + '/prop', data)
+    return instance._load_formatted_property('prop', folder + '/prop')
+
+
+@pytest.mark.parametrize('data', [
+    np.array([1 + 1j, 2 - 2j, -3 + 3j]),
+    np.array([1.5, -2.5, 3.0]),
+])
+def test_save_load_formatted_roundtrip(data, tmp_path):
+    """Formatted storage must round-trip complex arrays, not just real ones.
+
+    Regression test: a complex array (e.g. diffusivity) previously loaded back
+    as float and raised a ValueError because the dtype was not recorded in the
+    file header.
+    """
+    result = _roundtrip_formatted(data, tmp_path)
+    assert result.dtype == data.dtype
+    np.testing.assert_allclose(result, data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,10 @@ tag_prefix = ''
 
 [aliases]
 test = pytest
+
+[tool:pytest]
+# Register custom markers so pytest doesn't emit PytestUnknownMarkWarning.
+# Use `pytest -m performance` to run only marked tests, or
+# `pytest -m 'not performance'` to skip them.
+markers =
+    performance: tests that exercise large datasets or measure runtime; slower than the default suite


### PR DESCRIPTION
Bundles 4 small fixes that have been languishing in stale PRs (#221, #237, #239, #241). Each was a tiny change but the source branches drifted from main and accumulated 1.5M-line spurious diffs that made them unreviewable. Cherry-picked the actual contributions onto a fresh branch.

## What's in here

1. **Remove unnecessary `gc.collect()` calls from conductivity** (was #241)
   Python's reference counting already frees numpy arrays immediately. The explicit `gc.collect()` calls in `conductivity.py` added overhead by triggering full generational sweeps without benefit. Kept the `del` statements that reduce peak memory during the scattering matrix loop.

2. **Move ballistic early return before scattering matrix computation** (was #237)
   When `finite_length_method='ballistic'`, the full scattering matrix was being computed for each spatial direction before being discarded. Now the ballistic branch returns early. Closes #224.

3. **Fix tests for eigenvector basis dependence in degenerate subspaces** (was #239)
   `test_iso_bw` and `test_qhgk_conductivity` failed on arm64 while passing on x86 because LAPACK returns different eigenvector bases within degenerate subspaces depending on the platform. Fixed by:
   - `test_iso_bw`: assert the mean of the degenerate triplet (modes 3-5) instead of a single mode value (group mean is basis-invariant)
   - `test_qhgk_conductivity`: use `diffusivity_bandwidth=1.0` instead of the default per-mode bandwidth

   Closes #238.

4. **Fix formatted storage shape loss and refactor header parsing** (was #221)
   - Properties like `frequency` with shape `(1, n_modes)` for single-k-point systems lost their leading dimension through the `np.savetxt`/`np.loadtxt` round-trip, causing `frequency[0]` to return a scalar and breaking velocity calculation. Fix: store the original shape in the file header and restore it on load.
   - Make `Storable._save_formatted_property` and `_load_formatted_property` dimension-aware to handle 3D+ arrays with last dimension = 3.
   - Refactor: extract `_read_formatted_file` as a static method to deduplicate header parsing.

   Closes #243.

## Verification

Both previously-failing tests now pass:

```
$ pytest kaldo/tests/test_crystal_qe_vasp.py::test_qhgk_conductivity \
         kaldo/tests/test_ge_qe_crystal.py::test_iso_bw -v
test_qhgk_conductivity PASSED
test_iso_bw PASSED
```

Broader smoke (29 tests across `test_crystal.py`, `test_crystal_qe_vasp.py`, `test_ge_qe_crystal.py`, `test_lazy_loading.py`): all pass.

## Once this lands

Close as superseded: #221, #237, #239, #241.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced runtime overhead by removing explicit garbage-collection during QHGK conductivity/diffusivity and simplifying ballistic mean-free-path computation.
  * Standardized formatted velocity loading to follow the normal property-loading flow.
  * Overhauled formatted-property persistence with header-based dtype/shape inference, split-file support, and reliable shape restoration.

* **Tests**
  * Updated conductivity and isotopic-bandwidth regressions for more stable, basis-aware expectations.
  * Added formatted-storage save/load roundtrip tests for both float and complex arrays.

* **Chores**
  * Added an explicit `performance` pytest marker to prevent unknown-mark warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->