### PR TITLE
Block examples/ folder in CodeRabbit and fix broken example links

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -53,8 +53,9 @@ reviews:
         Flag float comparisons with `==` (use `np.isclose` / `np.allclose`),
         silent dtype downgrades from float64 to float32, and chained
         np.dot/np.tensordot where np.einsum / opt_einsum.contract would be
-        clearer. Watch for TensorFlow imports at module top level in modules
-        that should also load on CPU-only environments.
+        clearer. TensorFlow is a hard dependency in kaldo — top-level
+        `import tensorflow as tf` is the project convention; do not flag
+        it or suggest deferred imports.
     - path: "kaldo/**/*.py"
       instructions: >
         Apply DRY: flag duplicated logic across functions/modules that

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -35,7 +35,6 @@ reviews:
     - "!kaldo/tests/**/CONTCAR*"
     - "!kaldo/tests/**/CHGCAR*"
     - "!docs/**"
-    - "!examples/**/*.ipynb"
     - "!examples_local/**"
     - "!build/**"
     - "!dist/**"
@@ -77,6 +76,12 @@ reviews:
         chosen for the physics, not whatever makes them pass. Use tmp_path for
         any filesystem writes. Don't mock the filesystem to substitute for
         reference data files in sibling directories (si-crystal/, mgo/, etc.).
+    - path: "examples/**"
+      instructions: >
+        Block any new or modified files under examples/. kaldo's examples
+        live in nanotheorygroup/kaldo-examples — request the contributor
+        move the change there. Flag this as a blocker, not a nitpick:
+        re-introducing an examples/ folder in this repo is out of scope.
   pre_merge_checks:
     docstrings:
       mode: warning

--- a/docs/docsource/api_forceconstants.rst
+++ b/docs/docsource/api_forceconstants.rst
@@ -157,10 +157,10 @@ scratch directory skips finished atoms and only recomputes missing work.
                        delta_shift = 1e-5,
                        n_workers = 2,)
 
-.. _carbon diamond example: https://github.com/nanotheorygroup/kaldo/blob/main/examples/carbon_diamond_Tersoff_ASE_LAMMPS/1_C_Tersoff_fc_and_harmonic_properties.py
+.. _examples gallery: https://nanotheorygroup.github.io/kaldo-examples/
 
-Try referencing the `carbon diamond example`_ to see an example where we use kALDo and ASE to control LAMMPS
-calculations.
+See the `examples gallery`_ for end-to-end workflows that drive LAMMPS through ASE
+and other calculators.
 
 .. hint::
    Some libraries, like LAMMPS, can use either a python wrapper (LAMMPSlib) or a direct call to the binary
@@ -244,10 +244,8 @@ Common pitfalls
 Loading Precalculated IFCs
 **************************
 
-.. _amorphous silicon example: https://github.com/nanotheorygroup/kaldo/blob/main/examples/amorphous_silicon_Tersoff_LAMMPS/1_aSi512_Tersoff_thermal_conductivity.py
-
-Construct your ForceConstants object by using the :obj:`~kaldo.ForceConstants.from_folder` method. The first step of
-the `amorphous silicon example`_ can help you get started.
+Construct your ForceConstants object by using the :obj:`~kaldo.ForceConstants.from_folder` method;
+the `examples gallery`_ shows this pattern end-to-end.
 If you'd like to load IFCs into the already-created instances without the :py:meth:`from_folder` generate the
 ForceConstants object and then use the :py:meth:`load` method of the SecondOrder and ThirdOrder objects to pull data as
 needed.


### PR DESCRIPTION
## Summary
- Tell CodeRabbit to block any PR that reintroduces an `examples/` folder in this repo, since examples now live in [nanotheorygroup/kaldo-examples](https://github.com/nanotheorygroup/kaldo-examples).
- Drop the stale `!examples/**/*.ipynb` path filter (would have suppressed review on a reintroduced folder, defeating the new rule).
- Fix two broken links in `docs/docsource/api_forceconstants.rst` that pointed at the deleted in-repo examples; replace both with a single named target pointing at the published examples site (https://nanotheorygroup.github.io/kaldo-examples/) so the docs stay current as the gallery evolves.

## Test plan
- [ ] CodeRabbit picks up the new `path_instructions` entry on this PR (no `examples/` paths touched here, so it should be a no-op for this PR).
- [ ] Sphinx build of `docs/docsource/api_forceconstants.rst` resolves the new `examples gallery`_ named target without warnings.
- [ ] Manual click-through on the published doc site confirms the link lands on https://nanotheorygroup.github.io/kaldo-examples/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Example files now must be changed in the separate examples repository; new or modified files under examples are blocked and contributors are directed to move changes.
  * Updated reviewer guidance to accept the project convention of importing TensorFlow at module top level without requesting CPU-only flags or deferred-import suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->