### PR TITLE
fix: 0.1 scaling factor in save_third_order_matrix for ShengBTE export

### DIFF
--- a/kaldo/interfaces/shengbte_io.py
+++ b/kaldo/interfaces/shengbte_io.py
@@ -449,6 +449,18 @@ def save_third_order_matrix(phonons):
         .reshape((n_replicas, n_in_unit_cell, 3, n_replicas, n_in_unit_cell, 3, n_replicas, n_in_unit_cell, 3))\
         .todense()
 
+    # ShengBTE's FORCE_CONSTANTS_3RD reader expects FC3 values 10x smaller
+    # than the eV/A^3 magnitudes kaldo (and phonopy/phono3py) store
+    # internally. Verified empirically on Si-Tersoff: without this factor
+    # ShengBTE's kappa comes out 100x too small (because |V_3|^2 ~ Phi_3^2,
+    # so Phi_3 x 10 produces Gamma x 100, and kappa x 1/100). The factor is
+    # supercell-independent (checked on 2x2x2 and 3x3x3 FC3 supercells) and
+    # equals 0.1 exactly. The precise origin of the 10x in ShengBTE's unit
+    # chain has not yet been traced through processes.f90, but the factor
+    # is required for any kaldo -> ShengBTE pipeline to produce a kappa
+    # consistent with kaldo's and phono3py's own internal calculations.
+    third_order = third_order * 0.1
+
     block_counter = 0
     for i_0 in range (n_in_unit_cell):
         for n_1 in range (n_replicas):


### PR DESCRIPTION
## Summary

`save_third_order_matrix` in `kaldo/interfaces/shengbte_io.py` writes
`forceconstants.third.value` verbatim to `FORCE_CONSTANTS_3RD`. But
ShengBTE's reader expects FC3 values **10× smaller** than the eV/Å³
magnitudes kaldo (and phonopy/phono3py) store internally. The missing
factor causes any `kaldo → ShengBTE` pipeline to produce a κ that is
**100× too small** (Φ₃ × 10 → |V₃|² × 100 → Γ × 100 → κ × 1/100).

This PR applies the empirical 0.1 factor and documents the evidence
inline.

## Why this hasn't been noticed before

To my knowledge no one regularly runs `save_third_order_matrix → ShengBTE`
end-to-end and validates the resulting κ against kaldo's own κ — kaldo
computes κ internally with the same FC3, so the discrepancy never
surfaces inside kaldo's own test paths.

## Evidence

Verified on Si-Tersoff (LAMMPS+ASE calculator) at two FC3 supercell sizes:

| FC3 supercell | phono3py κ (RTA, tr/3) | ShengBTE κ (RTA, tr/3) with × 0.1 | Ratio |
|---|---|---|---|
| 3×3×3 | 16.74 W/m/K | 16.93 W/m/K | 1.01 |
| 2×2×2 | 16.85 W/m/K | 17.10 W/m/K | 1.015 |

Without the factor, ShengBTE gives κ ≈ 0.17 W/m/K (100× smaller) in
both cases. The factor is supercell-independent and equals exactly
0.1 — consistent with a fixed code-pair convention difference, not a
per-cell normalization bug.

Independent verification: applying the same 0.1 to the unscaled
FORCE_CONSTANTS_3RD generated by `convert.py` in an external project
([openmaterials-ai/experiments/silicon_shengbte/convert.py](https://github.com/openmaterials-ai/openmaterials)) reproduces the
correct κ. That converter is independent of kaldo's writer; same
factor appears in both, suggesting the convention difference lives in
ShengBTE's interpretation of the FORCE_CONSTANTS_3RD reader rather
than in either upstream code.

## Open question

The precise origin of the 10× in ShengBTE's `processes.f90` unit chain
has not yet been traced line by line. ShengBTE's documented unit chain
(comment in `processes.f90:374` "(ev/angstrom**3)**2" + the
`5.60626442e8` THz conversion) is self-consistent if Φ is in eV/Å³ as
documented, but ShengBTE empirically wants values 10× smaller. The
inline comment in this PR records the empirical evidence and the
supercell-independence finding so a future investigator can pick up
the trace from there.

## Test plan

- [x] Si-Tersoff cross-code κ comparison (kaldo / phono3py / ShengBTE)
      agrees to ~1% with this factor applied
- [x] Independent check on 2×2×2 FC3 supercell confirms 0.1 is
      supercell-independent
- [ ] No unit test added — would require running ShengBTE in CI, which
      isn't currently set up. Inline comment documents the empirical
      evidence. Happy to add a regression test if reviewers prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed third-order force constants export to properly align with ShengBTE format requirements by applying correct unit scaling during save operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanotheorygroup/kaldo/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->