### PR TITLE
Fix dos by replacing np.traz to spicy.integrate.trapezoid for numpy > 2.4.

### DIFF
--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -1328,8 +1328,7 @@ class Phonons(Storable):
                 for j in range(proj.shape[1]):
                     p_dos[ip, i] += np.sum(amp * proj[:, j, :] * physical_mode)
 
-            # TODO: np.trapz is deprecated in numpy 2.0+, but np.trapezoid does not exist before numpy 2.0. migrate it after this function gets removed. 
-            p_dos[ip] *= 3 * n_atoms / np.trapz(p_dos[ip], f_grid)
+            p_dos[ip] *= 3 * n_atoms / np.trapezoid(p_dos[ip], f_grid)
 
         return f_grid, p_dos
 

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -21,6 +21,7 @@ from concurrent.futures import as_completed
 from kaldo.parallel import dispatch_with_resume, get_executor
 from scipy import stats
 import numpy as np
+from scipy.integrate import trapezoid
 from numpy.typing import ArrayLike
 import ase.units as units
 from kaldo.helpers.tools import timeit
@@ -1328,7 +1329,7 @@ class Phonons(Storable):
                 for j in range(proj.shape[1]):
                     p_dos[ip, i] += np.sum(amp * proj[:, j, :] * physical_mode)
 
-            p_dos[ip] *= 3 * n_atoms / np.trapezoid(p_dos[ip], f_grid)
+            p_dos[ip] *= 3 * n_atoms / trapezoid(p_dos[ip], f_grid)
 
         return f_grid, p_dos
 


### PR DESCRIPTION
This PR addresses the usage of np.trapz for dumpy > 2.4. It breaks the current dos routine silently (i.e. raising a warning during the kaldo simulation but does not break the whole run), yet no dos/pdos will be generated. Substitute from np.trapz to spicy.integrate.trapezoid works and generates proper dos/pdos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the numerical integration used for phonon density of states (PDOS) normalization, switching to a trapezoidal integration approach for more reliable and consistent PDOS scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->