### PR TITLE
Add CPC 2026 paper as primary citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,76 @@
+cff-version: 1.2.0
+message: "If you use κALDo, please cite the following paper."
+title: "κALDo: Anharmonic Lattice Dynamics"
+abstract: >-
+  κALDo is an open-source Python package for computing vibrational, elastic,
+  and thermal transport properties of crystalline and disordered solids from
+  first principles and machine-learned interatomic potentials, implementing the
+  Boltzmann Transport Equation (BTE) and the Quasi-Harmonic Green-Kubo (QHGK)
+  method.
+type: software
+version: 2.1.0
+date-released: "2026-06-30"
+url: "https://github.com/nanotheorygroup/kaldo"
+repository-code: "https://github.com/nanotheorygroup/kaldo"
+license: BSD-3-Clause
+authors:
+  - given-names: Giuseppe
+    family-names: Barbalinardo
+    orcid: "https://orcid.org/0000-0002-7829-4403"
+  - given-names: Zekun
+    family-names: Chen
+    orcid: "https://orcid.org/0000-0002-4183-2941"
+  - given-names: Dylan A.
+    family-names: Folkner
+    orcid: "https://orcid.org/0000-0002-8715-7048"
+  - given-names: Bohan
+    family-names: Li
+    orcid: "https://orcid.org/0009-0000-9946-630X"
+  - given-names: Nicholas W.
+    family-names: Lundgren
+    orcid: "https://orcid.org/0000-0003-1914-0954"
+  - given-names: Nathaniel
+    family-names: Troup
+    orcid: "https://orcid.org/0009-0002-9789-2238"
+  - given-names: Alfredo
+    family-names: Fiorentino
+    orcid: "https://orcid.org/0000-0002-3048-5534"
+  - given-names: Davide
+    family-names: Donadio
+    orcid: "https://orcid.org/0000-0002-2150-4182"
+preferred-citation:
+  type: article
+  title: "κALDo 2.0: Scalable thermal transport from first principles and machine learning potentials"
+  authors:
+    - given-names: Giuseppe
+      family-names: Barbalinardo
+      orcid: "https://orcid.org/0000-0002-7829-4403"
+    - given-names: Zekun
+      family-names: Chen
+      orcid: "https://orcid.org/0000-0002-4183-2941"
+    - given-names: Dylan A.
+      family-names: Folkner
+      orcid: "https://orcid.org/0000-0002-8715-7048"
+    - given-names: Bohan
+      family-names: Li
+      orcid: "https://orcid.org/0009-0000-9946-630X"
+    - given-names: Nicholas W.
+      family-names: Lundgren
+      orcid: "https://orcid.org/0000-0003-1914-0954"
+    - given-names: Nathaniel
+      family-names: Troup
+      orcid: "https://orcid.org/0009-0002-9789-2238"
+    - given-names: Alfredo
+      family-names: Fiorentino
+      orcid: "https://orcid.org/0000-0002-3048-5534"
+    - given-names: Davide
+      family-names: Donadio
+      orcid: "https://orcid.org/0000-0002-2150-4182"
+  journal: "Computer Physics Communications"
+  volume: 327
+  start: 110282
+  year: 2026
+  doi: "10.1016/j.cpc.2026.110282"
+  url: "https://doi.org/10.1016/j.cpc.2026.110282"
+  publisher:
+    name: "Elsevier"

--- a/README.md
+++ b/README.md
@@ -151,26 +151,29 @@ If you use κALDo, please cite:
 
 | Reference | When to Cite |
 |-----------|--------------|
-| [1] | Any work using κALDo |
-| [2] | QHGK method for disordered materials |
-| [3] | Participation ratio analysis |
-| [4] | Finite-size thermal conductivity with BTE |
-| [5] | TDEP + path-integral MD workflows |
-| [6] | Isotopic scattering and hydrodynamic extrapolation |
+| [1] | Any work using κALDo (2.0) |
+| [2] | Original κALDo implementation (v1) |
+| [3] | QHGK method for disordered materials |
+| [4] | Participation ratio analysis |
+| [5] | Finite-size thermal conductivity with BTE |
+| [6] | TDEP + path-integral MD workflows |
+| [7] | Isotopic scattering and hydrodynamic extrapolation |
 
 ### References
 
-[1] G. Barbalinardo, Z. Chen, N.W. Lundgren, D. Donadio, *Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids*, [J. Appl. Phys. **128**, 135104 (2020)](https://aip.scitation.org/doi/10.1063/5.0020443).
+[1] G. Barbalinardo, Z. Chen, D.A. Folkner, B. Li, N.W. Lundgren, N. Troup, A. Fiorentino, D. Donadio, *κALDo 2.0: Scalable thermal transport from first principles and machine learning potentials*, [Comput. Phys. Commun. **327**, 110282 (2026)](https://doi.org/10.1016/j.cpc.2026.110282).
 
-[2] L. Isaeva, G. Barbalinardo, D. Donadio, S. Baroni, *Modeling heat transport in crystals and glasses from a unified lattice-dynamical approach*, [Nat. Commun. **10**, 3853 (2019)](https://www.nature.com/articles/s41467-019-11572-4).
+[2] G. Barbalinardo, Z. Chen, N.W. Lundgren, D. Donadio, *Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids*, [J. Appl. Phys. **128**, 135104 (2020)](https://aip.scitation.org/doi/10.1063/5.0020443).
 
-[3] N.W. Lundgren, G. Barbalinardo, D. Donadio, *Mode Localization and Suppressed Heat Transport in Amorphous Alloys*, [Phys. Rev. B **103**, 024204 (2021)](https://doi.org/10.1103/PhysRevB.103.024204).
+[3] L. Isaeva, G. Barbalinardo, D. Donadio, S. Baroni, *Modeling heat transport in crystals and glasses from a unified lattice-dynamical approach*, [Nat. Commun. **10**, 3853 (2019)](https://www.nature.com/articles/s41467-019-11572-4).
 
-[4] G. Barbalinardo, Z. Chen, H. Dong, Z. Fan, D. Donadio, *Ultrahigh convergent thermal conductivity of carbon nanotubes from comprehensive atomistic modeling*, [Phys. Rev. Lett. **127**, 025902 (2021)](https://doi.org/10.1103/PhysRevLett.127.025902).
+[4] N.W. Lundgren, G. Barbalinardo, D. Donadio, *Mode Localization and Suppressed Heat Transport in Amorphous Alloys*, [Phys. Rev. B **103**, 024204 (2021)](https://doi.org/10.1103/PhysRevB.103.024204).
 
-[5] D.A. Folkner, Z. Chen, G. Barbalinardo, F. Knoop, D. Donadio, *Elastic moduli and thermal conductivity of quantum materials at finite temperature*, [J. Appl. Phys. **136**, 221101 (2024)](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173).
+[5] G. Barbalinardo, Z. Chen, H. Dong, Z. Fan, D. Donadio, *Ultrahigh convergent thermal conductivity of carbon nanotubes from comprehensive atomistic modeling*, [Phys. Rev. Lett. **127**, 025902 (2021)](https://doi.org/10.1103/PhysRevLett.127.025902).
 
-[6] A. Fiorentino, P. Pegolo, S. Baroni, D. Donadio, *Effects of colored disorder on the heat conductivity of SiGe alloys from first principles*, [Phys. Rev. B **111**, 134205 (2025)](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205).
+[6] D.A. Folkner, Z. Chen, G. Barbalinardo, F. Knoop, D. Donadio, *Elastic moduli and thermal conductivity of quantum materials at finite temperature*, [J. Appl. Phys. **136**, 221101 (2024)](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173).
+
+[7] A. Fiorentino, P. Pegolo, S. Baroni, D. Donadio, *Effects of colored disorder on the heat conductivity of SiGe alloys from first principles*, [Phys. Rev. B **111**, 134205 (2025)](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205).
 
 ## Publications Using κALDo
 

--- a/docs/docsource/citations.md
+++ b/docs/docsource/citations.md
@@ -1,28 +1,32 @@
 ## How to cite
 
-[1] for any work that used `kALDo` 
+[1] for any work that used `kALDo` (2.0)
 
-[2] fundamental theory and implementations on Quasi-Harmonic Green Kubo (QHGK)
+[2] the original `kALDo` implementation (v1)
 
-[3] participation ratio 
+[3] fundamental theory and implementations on Quasi-Harmonic Green Kubo (QHGK)
 
-[4] finite size thermal conductivity calculations with ALD-BTE
+[4] participation ratio 
 
-[5] path-integral MD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations
+[5] finite size thermal conductivity calculations with ALD-BTE
 
-[6] isotopic scattering based on Tamura formula and hydrodynamic extrapolation 	
+[6] path-integral MD (from GPUMD) + TDEP + kALDo work flow and elastic moduli calculations
+
+[7] isotopic scattering based on Tamura formula and hydrodynamic extrapolation 	
 
 ## References
 
-[1] Giuseppe Barbalinardo, Zekun Chen, Nicholas W. Lundgren, Davide Donadio, [Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids](https://aip.scitation.org/doi/10.1063/5.0020443), J. Appl. Phys. **128**, 135104 (2020).
+[1] Giuseppe Barbalinardo, Zekun Chen, Dylan A. Folkner, Bohan Li, Nicholas W. Lundgren, Nathaniel Troup, Alfredo Fiorentino, Davide Donadio, [κALDo 2.0: Scalable thermal transport from first principles and machine learning potentials](https://doi.org/10.1016/j.cpc.2026.110282), Comput. Phys. Commun. **327**, 110282 (2026).
 
-[2] L Isaeva, G Barbalinardo, D Donadio, S Baroni, [Modeling heat transport in crystals and glasses from a unified lattice-dynamical approach](https://www.nature.com/articles/s41467-019-11572-4), Nat. Commun ***10***: 3853 (2019)
+[2] Giuseppe Barbalinardo, Zekun Chen, Nicholas W. Lundgren, Davide Donadio, [Efficient anharmonic lattice dynamics calculations of thermal transport in crystalline and disordered solids](https://aip.scitation.org/doi/10.1063/5.0020443), J. Appl. Phys. **128**, 135104 (2020).
 
-[3] Nicholas W. Lundgren, Giuseppe Barbalinardo, Davide Donadio, [Mode Localization and Suppressed Heat Transport in Amorphous Alloys](https://doi.org/10.1103/PhysRevB.103.024204), Phys. Rev. B **103**, 024204 (2021).
+[3] L Isaeva, G Barbalinardo, D Donadio, S Baroni, [Modeling heat transport in crystals and glasses from a unified lattice-dynamical approach](https://www.nature.com/articles/s41467-019-11572-4), Nat. Commun ***10***: 3853 (2019)
 
-[4] Giuseppe Barbalinardo, Zekun Chen, Haikuan Dong, Zheyong Fan, Davide Donadio,
+[4] Nicholas W. Lundgren, Giuseppe Barbalinardo, Davide Donadio, [Mode Localization and Suppressed Heat Transport in Amorphous Alloys](https://doi.org/10.1103/PhysRevB.103.024204), Phys. Rev. B **103**, 024204 (2021).
+
+[5] Giuseppe Barbalinardo, Zekun Chen, Haikuan Dong, Zheyong Fan, Davide Donadio,
 [Ultrahigh convergent thermal conductivity of carbon nanotubes from comprehensive atomistic modeling](https://doi.org/10.1103/PhysRevLett.127.025902), Phys. Rev. Lett. **127**, 025902 (2021).
 
-[5] Dylan A. Folkner, Zekun Chen, Giuseppe Barbalinardo, Florian Knoop, Davide Donadio, [Elastic moduli and thermal conductivity of quantum materials at finite temperature](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173), J. Appl. Phys. **136**,  221101 (2024).
+[6] Dylan A. Folkner, Zekun Chen, Giuseppe Barbalinardo, Florian Knoop, Davide Donadio, [Elastic moduli and thermal conductivity of quantum materials at finite temperature](https://pubs.aip.org/aip/jap/article/136/22/221101/3325173), J. Appl. Phys. **136**,  221101 (2024).
 
-[6] Alfredo Fiorentino,  Paolo Pegolo,  Stefano Baroni,  Davide Donadio, [Effects of colored disorder on the heat conductivity of SiGe alloys from first principles](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205), Phys. Rev. B. ***111***, 134205 (2025).
+[7] Alfredo Fiorentino,  Paolo Pegolo,  Stefano Baroni,  Davide Donadio, [Effects of colored disorder on the heat conductivity of SiGe alloys from first principles](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.111.134205), Phys. Rev. B. ***111***, 134205 (2025).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Scalable Thermal Transport from First Principles and Machine Learning Potentials
 
 **kALDo** is an open-source Python package for computing thermal transport properties of crystalline, disordered, and amorphous materials. It implements the **Boltzmann Transport Equation (BTE)** for crystals and the **Quasi-Harmonic Green-Kubo (QHGK)** method for systems lacking long-range order.
 
-Read the paper on `arXiv <https://arxiv.org/abs/2009.01967>`_.
+Read the κALDo 2.0 paper in `Computer Physics Communications <https://doi.org/10.1016/j.cpc.2026.110282>`_.
 
 
 .. toctree::


### PR DESCRIPTION
The κALDo 2.0 software paper is now published in Computer Physics Communications (327, 110282, 2026). Make it the primary reference [1] for any work using κALDo, and add a CITATION.cff so GitHub surfaces the "Cite this repository" button.

- README.md: CPC paper becomes [1]; the 2020 JAP paper moves to [2] ("original implementation, v1"); remaining references shifted to [3]-[7]
- docs/docsource/citations.md: same reordering
- docs/index.rst: replace the arXiv preprint link with the published DOI
- CITATION.cff: new, with preferred-citation pointing at the CPC paper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and completed repository citation metadata, including citation format, project details, version, release date, license, authors, and a preferred citation entry.
  * Updated the README citations section to include an additional reference and align the reference list accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->