### PR TITLE
Force Constant Type Heirarchy

### DIFF
--- a/kaldo/interfaces/AbstractIFCFormat.py
+++ b/kaldo/interfaces/AbstractIFCFormat.py
@@ -1,0 +1,107 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+
+class AbstractForceConstantStorageFormat(ABC):
+
+    def __init(self, ifcs, fmt_type, err_msg):
+        try:
+            self.order = fmt_type.order_map[len(ifcs.shape)]
+        except KeyError:
+            raise KeyError(err_msg)
+        
+        self.ifcs = ifc_tensor
+
+
+    # Define dunder methods so this type acts like a raw numpy array
+    #! MIGHT NEED OTHER ONES
+    def __getitem__(self, index):
+        return self.ifcs[index]
+
+    def __setitem__(self, index, value):
+        self.ifcs[index] = value
+
+    def __len__(self):
+        return len(self.ifcs)
+
+    def __iter__(self):
+        return iter(self.ifcs)
+
+    def __next__(self):
+        return next(self.ifcs)
+
+
+class ReplicaForceConstantFormat(AbstractForceConstantStorageFormat):
+
+    order_map = {
+        6 : 2,
+        9 : 3,
+        11: 4,
+    }
+
+    def __init__(self, ifcs):
+        err_msg = f"Replica IFC format has invalid shape: {ifcs.shape}." + 
+                            "Expected something like (n_replicas, n_unit_atoms, 3, n_replicas, n_unit_atoms, 3)"
+        super().__init__(ifcs, ReplicaForceConstantFormat, err_msg)
+        
+    @abstractmethod
+    def to_block_sparse_fmt(self) -> BlockSparseForceConstantFormat:
+        pass
+
+#! IM NOT SURE WHAT TO CALL THIS FORMAT
+class BlockSparseForceConstantFormat(AbstractForceConstantStorageFormat):
+    """
+    In neighbor list format IFCs store all interactions between primitive atoms and supercell atoms.
+    Second order IFCs have shape: (n_unit_atoms, n_sc, 3, 3)
+    Third order IFCs have shape: (n_unit_atoms, n_sc, n_sc, 3, 3, 3)
+    Fourth order IFCs have shape: (n_unit_atoms, n_sc, n_sc, n_sc, 3, 3, 3, 3)
+
+    This is the default format used by TDEP, and naturally maps on to block sparse formats.
+    """
+
+    order_map = {
+        4 : 2,
+        6 : 3,
+        8 : 4,
+    }
+
+    def __init__(self, ifcs):
+        err_msg = f"Neighbor list IFC format has invalid shape: {ifcs.shape}." + 
+                            "Expected something like (n_unit_atoms, n_sc, 3, 3)"
+        super().__init__(ifcs, BlockSparseForceConstantFormat, err_msg)
+
+    @abstractmethod
+    def to_replica_fmt(self) -> ReplicaForceConstantFormat:
+        pass
+
+class AbstractForceConstantFormat(ABC):
+    
+    @abstractmethod
+    def load_second_order(
+        self,
+        filename : str,
+        supercell : tuple[int, int, int],
+    ) -> SecondOrder:
+        pass
+
+    @abstractmethod
+    def load_third_order(
+        self,
+        filename : str,
+        supercell : tuple[int, int, int],
+    ) -> ThirdOrder:
+        pass
+
+    @abstractmethod
+    def load_fourth_order(
+        self,
+        filename : str,
+        supercell : tuple[int, int, int],
+    ) -> FourthOrder:
+        pass    
+
+    @abstractmethod
+    def convert_storage_to(
+        self,
+        storage_fmt : AbstractForceConstantStorageFormat,
+    ) -> AbstractForceConstantFormat:
+        pass

--- a/kaldo/interfaces/tdep_io.py
+++ b/kaldo/interfaces/tdep_io.py
@@ -11,6 +11,57 @@ from sparse import COO
 logging = get_logger()
 
 
+class TDEP(AbstractForceConstantFormat):
+
+    def __init__(
+        self,
+        ucposcar_path : str,
+        ssposcar_path : str,   
+    ):
+        self.storage_fmt = ForceConstantStorageFormat.REPLICA_FMT
+
+        self.ucposcar_path = ucposcar_path
+        self.ssposcar_path = ssposcar_path
+
+        self.uc = ase.io.read(ucposcar_path, format="vasp")
+        self.sc = ase.io.read(ssposcar_path, format="vasp")
+
+
+    def load_second_order(
+        self,
+        ifc_path : str,
+        supercell : tuple[int, int, int],
+    ) -> SecondOrder:
+        d2 = parse_tdep_forceconstant(
+            fc_file=ifc_path,
+            primitive=self.ucposcar_path,
+            supercell=self.ssposcar_path,
+            reduce_fc=False,
+        )
+
+        n_unit_atoms = self.uc.positions.shape[0]
+        n_replicas = np.prod(supercell)
+        d2 = d2.reshape((n_replicas, n_unit_atoms, 3, n_replicas, n_unit_atoms, 3))
+        d2 = d2[0, np.newaxis]
+
+        ifc2 = ReplicaForceConstantFormat(d2)
+
+        return SecondOrder(
+            atoms=self.uc,
+            replicated_positions=self.sc.positions,
+            supercell=supercell,
+            value=ifc2,
+            folder=os.path.dirname(ifc_path)
+        )
+
+    def load_third_order():
+        #TODO
+        pass
+
+    def load_fourth_order():
+        #TODO
+        pass
+
 # --------------------------------
 # Second order force constant method
 

--- a/kaldo/observables/forceconstant.py
+++ b/kaldo/observables/forceconstant.py
@@ -19,7 +19,7 @@ class ForceConstant(Observable):
                  replicated_positions: NDArray,
                  supercell: tuple[int, int, int],
                  folder: str,
-                 value: ArrayLike | None = None,
+                 value: ArrayLike | AbstractForceConstantStorageFormat | None = None,
                  grid: Grid | None = None,
                  **kwargs):
         super().__init__(folder=folder, **kwargs)

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -235,24 +235,19 @@ class SecondOrder(ForceConstant):
                     )
 
             case "tdep":
+                
                 uc_filename = "infile.ucposcar"
                 replicated_filename = "infile.ssposcar"
                 atom_prime_file = os.path.join(folder, uc_filename)
                 replicated_atom_prime_file = os.path.join(folder, replicated_filename)
-                uc = ase.io.read(atom_prime_file, format="vasp")
-                sc = ase.io.read(replicated_atom_prime_file, format="vasp")
-                d2 = parse_tdep_forceconstant(
-                    fc_file=os.path.join(folder, "infile.forceconstant"),
-                    primitive=atom_prime_file,
-                    supercell=replicated_atom_prime_file,
-                    reduce_fc=False,
+
+                tdep_io = TDEP(
+                    ucposcar_path=atom_prime_file,
+                    ssposcar_path=replicated_atom_prime_file,
                 )
-                n_unit_atoms = uc.positions.shape[0]
-                n_replicas = np.prod(supercell)
-                d2 = d2.reshape((n_replicas, n_unit_atoms, 3, n_replicas, n_unit_atoms, 3))
-                d2 = d2[0, np.newaxis]
-                second_order = SecondOrder(
-                    atoms=uc, replicated_positions=sc.positions, supercell=supercell, value=d2, folder=folder
+               return tdep_io.load_second_order(
+                    ifc_path=os.path.join(folder, "infile.forceconstant"),
+                    supercell=supercell,
                 )
 
             case _:


### PR DESCRIPTION
This PR outlines a type hierarchy I think would be beneficial to adopt for code cleanliness, correctness and extensibility long-term. This is just an outline/proposal of the types and how they might be used. I have not fully implemented or checked correctness. This was inspired by some problems I ran in to while trying to implement the cumulant expansion and some bottlenecks I observed with the existing COO format. 

At a high-level I have added two abstract types: `AbstractForceConstantStorageFormat` and `AbstractForceConstantFormat`. 


IFC Storage Formats:
----------------------
The goal of the storage format type is to enable conversion between internal storage formats easily and to provide a stronger contract and more information about `self.value` in `SecondOrder`. I envision two sub-types to begin: `ReplicaFormat` and `BlockSparseFormat`. The `ReplicaFormat` is what kaldo already uses where force constant are stored in a COO tensor with shape like `(n_uc, 3, n_replica, n_uc, 3)`. `BlockSparseFormat` is what TDEP natively uses and naturally embeds the neighbor list and extends to fourth-order better than a COO array. 

These types implement dunder methods like `__getitem__` so they behave exactly like `self.value` does in `SecondOrder` today, but because they are classes they contain extra metadata, have the ability to enforce/check formatting rules and encapsulate methods to convert between the formats easily.

IFC Format Types:
---------------------
The goal of these types was mainly cleanliness. They pull out the implementation inside `SecondOrder.load` into library specific types. Here I have implemented the `TDEP` type. Most of the logic was already in the `interfaces` folder, but adding a class just helps tie things together and provide better abstraction.
