### PR TITLE
Relax QHGK conductivity test tolerance

### DIFF
--- a/kaldo/tests/test_io.py
+++ b/kaldo/tests/test_io.py
@@ -36,7 +36,7 @@ def phonons():
 def test_qhgk_conductivity(phonons):
     cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 141, significant=3)
+    np.testing.assert_allclose(cond, 141.0, rtol=2e-2, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):


### PR DESCRIPTION
## Summary

Relax the QHGK conductivity regression test tolerance to account for the cross-backend spread observed with the default adaptive diffusivity bandwidth.

Different BLAS/LAPACK backends may select different eigenvector bases inside degenerate subspaces, resulting in small differences in the computed conductivity. Across macOS ARM64 with Accelerate, macOS ARM64 with OpenBLAS, and Linux x86-64 with OpenBLAS, the measured values ranged from `139.72577` to `141.06184`.

The updated tolerance covers this observed numerical envelope.

Related to #238.
Closes #270.

## Testing

The following tests were run locally to validate the change:

* `pytest kaldo/tests/test_io.py::test_qhgk_conductivity -v`
* `pytest kaldo/tests/test_io.py -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated conductivity validation to use a relative-tolerance comparison, allowing results within 2% of the expected value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->