### PR TITLE
Declare the C replica order the vasp readers produce

### DIFF
--- a/kaldo/forceconstants.py
+++ b/kaldo/forceconstants.py
@@ -4,7 +4,7 @@ Anharmonic Lattice Dynamics
 """
 import numpy as np
 from sparse import COO
-from kaldo.grid import wrap_coordinates, Grid
+from kaldo.grid import wrap_coordinates
 from kaldo.observables.secondorder import SecondOrder
 from kaldo.observables.thirdorder import ThirdOrder
 from kaldo.observables.fourthorder import FourthOrder
@@ -350,16 +350,13 @@ class ForceConstants:
         atoms = self.atoms
         masses = atoms.get_masses()
         volume = atoms.get_volume()
+        # The dynmat replica axis and list_of_replicas both follow the grid
+        # declared by the loader, so they pair directly. A former
+        # unconditional C-override here compensated for loaders that
+        # declared F over C-ordered data (QE fixed in #272, VASP alongside
+        # this change); on self-consistent F loads such as hiphive it
+        # mispaired the vectors and corrupted the tensor.
         list_of_replicas = self.second.list_of_replicas
-
-        # Rest of the code for elastic tensor assumes C-type grid
-        # Generate C-type grid if needed
-        if self.second._direct_grid.order == 'F':
-            list_of_replicas = (
-                Grid(self.second.supercell, order='C')
-                .grid(is_wrapping=True)
-                .dot(self.atoms.cell)
-            )
 
         dynmat = self.second.dynmat[0]  # units THz^2
         positions = self.atoms.positions

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -197,8 +197,10 @@ class SecondOrder(ForceConstant):
                             raise FileNotFoundError(f"File {filename} not found.")
                         _second_order = shengbte_io.read_second_order_matrix(filename, supercell)
                         _second_order = _second_order.reshape((n_unit_atoms, 3, n_replicas, n_unit_atoms, 3))
-                        # must stay "F" together with the vasp-* case in ThirdOrder.load
-                        grid_type = "F"
+                        # the reader's replica axis is C-ordered, like the QE
+                        # case above; declared together with the vasp-* case in
+                        # ThirdOrder.load (see #272 for the QE analogue)
+                        grid_type = "C"
                 second_order = SecondOrder.from_supercell(
                     atoms=atoms,
                     grid_type=grid_type,

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -144,12 +144,9 @@ class ThirdOrder(ForceConstant):
                                          folder=folder)
 
             case ("vasp-sheng" | "shengbte") | ("qe-sheng" | "shengbte-qe") | ("qe-d3q" | "shengbte-d3q") | "vasp-d3q":
-                # must match the grid declared by SecondOrder.load for the same format
-                match format:
-                    case ("qe-sheng" | "shengbte-qe") | ("qe-d3q" | "shengbte-d3q"):
-                        grid_type = 'C'
-                    case _:
-                        grid_type = 'F'
+                # all these readers produce C-ordered replica data; declared
+                # together with SecondOrder.load for the same formats (#272)
+                grid_type = 'C'
                 config_path, config_file = detect_path(['CONTROL', 'POSCAR'], folder)
                 match config_file:
                     case 'CONTROL':

--- a/kaldo/tests/test_crystal_vasp_d3q.py
+++ b/kaldo/tests/test_crystal_vasp_d3q.py
@@ -27,21 +27,35 @@ def phonons():
     )
     return phonons
 
+# Reference values re-pinned when the vasp-* loaders were fixed to declare
+# the C replica order their readers actually produce (previously declared F
+# over C-ordered data). On this cubic fixture the conductivity shift from
+# the relabeling is comparable to the cross-backend spread from the
+# eigenvector-basis freedom in degenerate subspaces (see #270), so these
+# tests are regression sanity bands, not enumeration detectors: references
+# sit at the midpoint of the values observed on x86-64/OpenBLAS
+# (0.813 / 0.676 / 0.725) and arm64/Accelerate (0.837 / 0.700 / 0.750),
+# with rtol covering that spread. The enumeration itself is pinned by
+# test_elastic_vasp (cubic tensor form holds at machine precision only
+# under C pairing) and by the relabeling-invariance test in
+# test_elastic.py.
+
+
 def test_qhgk_conductivity(phonons):
     cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 0.81, significant=2)
+    np.testing.assert_allclose(cond, 0.825, rtol=3e-2, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 0.68, significant=2)
+    np.testing.assert_allclose(cond, 0.688, rtol=3e-2, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 0.73, significant=2)
+    np.testing.assert_allclose(cond, 0.738, rtol=3e-2, atol=0.0)

--- a/kaldo/tests/test_elastic.py
+++ b/kaldo/tests/test_elastic.py
@@ -28,3 +28,45 @@ def test_c12(forceconstants):
 def test_c44(forceconstants):
     cijkl = forceconstants.elastic_prop()
     np.testing.assert_approx_equal(cijkl[1, 2, 1, 2], 69.06, significant=3)
+
+
+def test_elastic_prop_invariant_under_grid_relabeling(tmp_path):
+    """elastic_prop must not depend on the replica enumeration convention.
+
+    A C-ordered SecondOrder and a self-consistent F-relabeled twin (same
+    physics: value replica axis permuted together with the declared grid)
+    must give identical elastic tensors. A random seeded value tensor on an
+    asymmetric supercell makes the check maximally discriminating: any code
+    path that overrides the declared enumeration instead of trusting the
+    grid/value pair mispairs replica vectors against the dynamical matrix
+    and fails this test.
+    """
+    from ase.build import bulk
+    from kaldo.grid import Grid
+    from kaldo.observables.secondorder import SecondOrder
+
+    atoms = bulk("Si", "diamond", a=5.43)
+    supercell = (2, 2, 3)
+    n_uc, n_rep = len(atoms), int(np.prod(supercell))
+
+    rng = np.random.default_rng(0)
+    value_c = rng.standard_normal((1, n_uc, 3, n_rep, n_uc, 3)).astype(np.float64)
+
+    # Permutation p with grid_F[k] == grid_C[p[k]] (pure enumeration order)
+    grid_c = Grid(supercell, order="C").grid(is_wrapping=False)
+    grid_f = Grid(supercell, order="F").grid(is_wrapping=False)
+    p = np.array([np.flatnonzero((grid_c == gf).all(axis=1))[0] for gf in grid_f])
+    value_f = value_c[:, :, :, p, :, :]
+
+    second_c = SecondOrder.from_supercell(atoms, grid_type="C", supercell=supercell,
+                                          value=value_c, folder=str(tmp_path / "c"))
+    second_f = SecondOrder.from_supercell(atoms, grid_type="F", supercell=supercell,
+                                          value=value_f, folder=str(tmp_path / "f"))
+
+    fc_c = ForceConstants(atoms=atoms, supercell=supercell, second_order=second_c,
+                          folder=str(tmp_path / "c"))
+    fc_f = ForceConstants(atoms=atoms, supercell=supercell, second_order=second_f,
+                          folder=str(tmp_path / "f"))
+
+    np.testing.assert_allclose(fc_f.elastic_prop(), fc_c.elastic_prop(),
+                               rtol=1e-10, atol=1e-10)


### PR DESCRIPTION
## Motivation

The vasp-* branches of `SecondOrder.load` and `ThirdOrder.load` declared an F-ordered replica grid over data their readers produce in C order, the VASP twin of the QE mislabel fixed in #272 (item 2 of #279). The mismatch pairs replica vectors with the wrong force-constant blocks, and it is not a symmetry relabeling (labels flip without rotating Cartesian components), so it distorts results even on cubic fixtures.

`elastic_prop` carried an unconditional compensation for this (thanks @bkhli, it was doing real load-bearing work for vasp loads): whenever the declared grid was F it regenerated the replica list in C order. Correct for the vasp mislabel, but it corrupted self-consistent F loads such as hiphive, whose grid and data enumeration agree. Review iterations that kept the compensation (conditional stamps, a value-order property) all amounted to encoding an exception for vasp; the clean fix is for the loaders to declare the order their data actually uses, so no exception exists anywhere.

## Evidence that C is the data's enumeration

- **Second order**: with C pairing the vasp Si stiffness tensor satisfies the cubic equal-constant relations to machine precision (spread 7e-13) and matches the pinned `test_elastic_vasp` references; with F pairing the cubic form is destroyed (spread 1.4e2 GPa).
- **Third order**: both vasp third readers are invoked with `order='C'` and map the file's explicit lattice vectors onto a C-raveled index, the same convention #272 validated for qe-d3q.

## What changed

- vasp-* second and third order now declare `grid_type='C'` (flipped together, mirroring #272).
- `elastic_prop` trusts the loader's grid; the unconditional C-override is gone.
- The vasp-d3q Ge conductivity references are re-pinned as explicit cross-backend bands (`assert_allclose`, rtol=3e-2, centered between the observed x86-64/OpenBLAS and arm64/Accelerate values). On this cubic fixture the relabeling shift is comparable to the degenerate-subspace backend spread documented in #270, so these tests are sanity bands, not enumeration detectors; the enumeration is pinned by `test_elastic_vasp` and the new invariance test.
- New enumeration-invariance regression test in `test_elastic.py`: a C-ordered `SecondOrder` and a self-consistent F-relabeled twin of the same random value tensor on an asymmetric (2, 2, 3) supercell must give identical elastic tensors. It fails against the old unconditional override.

## Testing

Full local suite: 219 passed, 10 env-gated skips. The re-pinned bands were verified to contain both observed backend values for all three conductivity methods.

Resolves the vasp half of #279 item 2; validating the third order on an anisotropic vasp dataset (e.g. AlmaBTE GaN) remains desirable and is noted there.