### PR TITLE
Add PhononsEnsemble for harmonic uncertainty quantification

### DIFF
--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -37,3 +37,46 @@ class PhononsEnsemble:
     def n_members(self):
         """Number of members in the ensemble."""
         return len(self._members)
+
+    def _stack(self, observable):
+        """Stack the named per-mode property across members: shape (n_members, ...).
+
+        Aggregation is sorted-stack: kaldo returns frequencies sorted ascending per
+        q-point, so member axis m tracks the same branch away from band crossings.
+        At crossings and in degenerate subspaces the ordering can swap branches,
+        which slightly overestimates the std there.
+        """
+        arrays = []
+        for i, member in enumerate(self._members):
+            try:
+                value = getattr(member, observable)
+            except AttributeError as exc:
+                raise AttributeError(
+                    f"Ensemble member has no property {observable!r}. "
+                    "mean_std aggregates scalar per-mode Phonons properties such as "
+                    "'frequency', 'heat_capacity', 'participation_ratio', 'bandwidth'."
+                ) from exc
+            arr = np.asarray(value)
+            if i == 0:
+                ref_shape = arr.shape
+            elif arr.shape != ref_shape:
+                raise ValueError(
+                    f"Ensemble members disagree on the shape of {observable!r}: "
+                    f"member 0 has {ref_shape}, member {i} has {arr.shape}. "
+                    "All members must share kpts and system size."
+                )
+            arrays.append(arr)
+        return np.stack(arrays, axis=0)
+
+    def mean(self, observable):
+        """Mean of the named per-mode property across members."""
+        return self._stack(observable).mean(axis=0)
+
+    def std(self, observable):
+        """Standard deviation of the named per-mode property across members."""
+        return self._stack(observable).std(axis=0)
+
+    def mean_std(self, observable):
+        """Return (mean, std) of the named per-mode property across members."""
+        stacked = self._stack(observable)
+        return stacked.mean(axis=0), stacked.std(axis=0)

--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -8,9 +8,6 @@ import numpy as np
 
 from kaldo.forceconstants import ForceConstants
 from kaldo.phonons import Phonons
-from kaldo.helpers.logger import get_logger
-
-logging = get_logger()
 
 
 class PhononsEnsemble:
@@ -62,15 +59,17 @@ class PhononsEnsemble:
         base_folder = phonons_kwargs.get('folder', None)
         members = []
         for i, calc in enumerate(calculators):
-            fc_folder = (f"{base_folder}/member_{i}" if base_folder
-                         else f"ensemble_member_{i}")
+            member_folder = f"{base_folder}/member_{i}" if base_folder else f"ensemble_member_{i}"
             fc = ForceConstants(atoms=atoms, supercell=supercell,
-                                folder=fc_folder)
+                                folder=member_folder)
             fc.second.calculate(calculator=calc, delta_shift=delta_shift,
                                 is_storing=False, symmetrize=False)
+            # Give each member a distinct Phonons folder as well, so on-disk
+            # storage does not have the members clobber each other's output.
+            member_kwargs = dict(phonons_kwargs, folder=member_folder)
             members.append(cls._member_from_second(
                 atoms, supercell, fc.second, symmetrize=symmetrize,
-                phonons_kwargs=phonons_kwargs))
+                phonons_kwargs=member_kwargs))
         return cls(members)
 
     @staticmethod

--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -1,0 +1,39 @@
+"""Ensemble uncertainty quantification for harmonic phonon properties.
+
+Aggregates a scalar per-mode Phonons property (e.g. frequency) across N committee
+members into a mean and standard deviation. Model-agnostic: members are ordinary
+Phonons objects, however they were produced.
+"""
+import numpy as np
+
+from kaldo.forceconstants import ForceConstants
+from kaldo.phonons import Phonons
+from kaldo.helpers.logger import get_logger
+
+logging = get_logger()
+
+
+class PhononsEnsemble:
+    """A collection of Phonons members with mean/std aggregation of properties.
+
+    Parameters
+    ----------
+    phonons_list : list of Phonons
+        One Phonons object per committee member. Must be non-empty.
+    """
+
+    def __init__(self, phonons_list):
+        members = list(phonons_list)
+        if len(members) == 0:
+            raise ValueError("PhononsEnsemble needs at least one member.")
+        self._members = members
+
+    @property
+    def members(self):
+        """List of Phonons members."""
+        return self._members
+
+    @property
+    def n_members(self):
+        """Number of members in the ensemble."""
+        return len(self._members)

--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -28,6 +28,51 @@ class PhononsEnsemble:
             raise ValueError("PhononsEnsemble needs at least one member.")
         self._members = members
 
+    @classmethod
+    def from_calculators(cls, atoms, supercell, calculators, *,
+                         delta_shift=1e-2, symmetrize=True, **phonons_kwargs):
+        """Build an ensemble from N independent ASE calculators.
+
+        For each calculator, run a finite-difference second-order calculation,
+        optionally symmetrize the force constants (kaldo 2.2.0), and build a
+        Phonons member. Suited to a handful of independent committee members;
+        get_forces() is called serially per member.
+
+        Parameters
+        ----------
+        atoms : ase.Atoms
+            Unit cell (same for every member).
+        supercell : tuple of int, length 3
+            Supercell for the finite-difference second-order calculation.
+        calculators : list of ASE calculators
+            One calculator per committee member. Must be non-empty.
+        delta_shift : float, optional
+            Finite-difference displacement in Angstrom. Default 1e-2.
+        symmetrize : bool, optional
+            Project each member's force constants onto the space-group-invariant
+            subspace. Default True.
+        **phonons_kwargs
+            Forwarded to each Phonons (kpts, temperature, is_classic, storage,
+            folder, ...).
+        """
+        calculators = list(calculators)
+        if len(calculators) == 0:
+            raise ValueError("from_calculators needs at least one calculator.")
+
+        base_folder = phonons_kwargs.get('folder', None)
+        members = []
+        for i, calc in enumerate(calculators):
+            fc_folder = (f"{base_folder}/member_{i}" if base_folder
+                         else f"ensemble_member_{i}")
+            fc = ForceConstants(atoms=atoms, supercell=supercell,
+                                folder=fc_folder)
+            fc.second.calculate(calculator=calc, delta_shift=delta_shift,
+                                is_storing=False, symmetrize=False)
+            members.append(cls._member_from_second(
+                atoms, supercell, fc.second, symmetrize=symmetrize,
+                phonons_kwargs=phonons_kwargs))
+        return cls(members)
+
     @staticmethod
     def _member_from_second(atoms, supercell, second_order, symmetrize, phonons_kwargs):
         """Build one Phonons member from a computed SecondOrder.

--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -28,6 +28,19 @@ class PhononsEnsemble:
             raise ValueError("PhononsEnsemble needs at least one member.")
         self._members = members
 
+    @staticmethod
+    def _member_from_second(atoms, supercell, second_order, symmetrize, phonons_kwargs):
+        """Build one Phonons member from a computed SecondOrder.
+
+        If symmetrize is True, projects the force constants onto the
+        space-group-invariant subspace (kaldo 2.2.0). Wraps the SecondOrder in a
+        ForceConstants and constructs a Phonons with phonons_kwargs.
+        """
+        if symmetrize:
+            second_order.symmetrize()
+        fc = ForceConstants(atoms=atoms, supercell=supercell, second_order=second_order)
+        return Phonons(forceconstants=fc, **phonons_kwargs)
+
     @property
     def members(self):
         """List of Phonons members."""

--- a/kaldo/ensemble.py
+++ b/kaldo/ensemble.py
@@ -48,15 +48,13 @@ class PhononsEnsemble:
         """
         arrays = []
         for i, member in enumerate(self._members):
-            try:
-                value = getattr(member, observable)
-            except AttributeError as exc:
+            if not hasattr(type(member), observable):
                 raise AttributeError(
                     f"Ensemble member has no property {observable!r}. "
                     "mean_std aggregates scalar per-mode Phonons properties such as "
                     "'frequency', 'heat_capacity', 'participation_ratio', 'bandwidth'."
-                ) from exc
-            arr = np.asarray(value)
+                )
+            arr = np.asarray(getattr(member, observable))
             if i == 0:
                 ref_shape = arr.shape
             elif arr.shape != ref_shape:

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -86,3 +86,26 @@ def test_shape_mismatch_across_members_raises(tmp_path):
     ens = PhononsEnsemble([m_a, m_b])
     with pytest.raises(ValueError, match="disagree on the shape"):
         ens.mean_std('frequency')
+
+
+def test_from_calculators_deterministic_zero_std(tmp_path):
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    ens = PhononsEnsemble.from_calculators(
+        atoms, (2, 2, 2), [EMT(), EMT(), EMT()],
+        delta_shift=1e-2, symmetrize=True,
+        kpts=(3, 3, 3), temperature=300, storage='memory',
+        folder=str(tmp_path / 'ald'),
+    )
+    assert ens.n_members == 3
+    mean, std = ens.mean_std('frequency')
+    np.testing.assert_allclose(std, 0.0, atol=1e-8)
+    assert np.all(np.isfinite(mean))
+
+
+def test_from_calculators_empty_raises():
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    with pytest.raises(ValueError, match="at least one"):
+        PhononsEnsemble.from_calculators(
+            atoms, (2, 2, 2), [], kpts=(3, 3, 3), temperature=300,
+            storage='memory'
+        )

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -143,3 +143,18 @@ def test_single_member_zero_std(tmp_path):
     assert ens.n_members == 1
     _, std = ens.mean_std('frequency')
     np.testing.assert_allclose(std, 0.0, atol=1e-12)
+
+
+def test_from_calculators_gives_members_distinct_folders(tmp_path):
+    # Regression: on-disk storage must not have members clobber each other.
+    # Each member's Phonons folder must be distinct (member_i under base).
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    base = str(tmp_path / 'ald')
+    ens = PhononsEnsemble.from_calculators(
+        atoms, (2, 2, 2), [EMT(), EMT()],
+        delta_shift=1e-2, symmetrize=True,
+        kpts=(3, 3, 3), temperature=300, storage='numpy', folder=base,
+    )
+    folders = [m.folder for m in ens.members]
+    assert folders == [f"{base}/member_0", f"{base}/member_1"]
+    assert len(set(folders)) == ens.n_members

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -123,7 +123,6 @@ def _perturbed_second(atoms, base_second, scale, seed):
 
 def test_symmetrization_reduces_gamma_frequency_spread(tmp_path):
     atoms, base_second = _cu_second(tmp_path, 'base')
-    seconds = [_perturbed_second(atoms, base_second, scale=1e-2, seed=s) for s in range(4)]
 
     def build(symmetrize):
         members = [PhononsEnsemble._member_from_second(

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -29,3 +29,28 @@ def test_members_and_count(tmp_path):
 def test_empty_ensemble_raises():
     with pytest.raises(ValueError, match="at least one member"):
         PhononsEnsemble([])
+
+
+def test_identical_members_zero_std(tmp_path):
+    members = _cu_phonons(tmp_path, n=3)
+    ens = PhononsEnsemble(members)
+    mean, std = ens.mean_std('frequency')
+    ref = np.asarray(members[0].frequency)
+    assert mean.shape == ref.shape
+    np.testing.assert_allclose(mean, ref, rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(std, 0.0, atol=1e-10)
+
+
+def test_mean_and_std_helpers_match_mean_std(tmp_path):
+    members = _cu_phonons(tmp_path, n=2)
+    ens = PhononsEnsemble(members)
+    mean, std = ens.mean_std('frequency')
+    np.testing.assert_array_equal(ens.mean('frequency'), mean)
+    np.testing.assert_array_equal(ens.std('frequency'), std)
+
+
+def test_unknown_observable_raises_helpful(tmp_path):
+    members = _cu_phonons(tmp_path, n=1)
+    ens = PhononsEnsemble(members)
+    with pytest.raises(AttributeError, match="not_a_prop"):
+        ens.mean_std('not_a_prop')

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -54,3 +54,32 @@ def test_unknown_observable_raises_helpful(tmp_path):
     ens = PhononsEnsemble(members)
     with pytest.raises(AttributeError, match="not_a_prop"):
         ens.mean_std('not_a_prop')
+
+
+def _cu_second(tmp_path, folder):
+    """Compute one raw (unsymmetrized) SecondOrder for Cu via EMT."""
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    fc = ForceConstants(atoms=atoms, supercell=(2, 2, 2), folder=str(tmp_path / folder))
+    fc.second.calculate(calculator=EMT(), delta_shift=1e-2, is_storing=False, symmetrize=False)
+    return atoms, fc.second
+
+
+def test_member_from_second_builds_phonons(tmp_path):
+    atoms, second = _cu_second(tmp_path, 'a')
+    member = PhononsEnsemble._member_from_second(
+        atoms, (2, 2, 2), second, symmetrize=True, phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory')
+    )
+    assert isinstance(member, Phonons)
+    assert np.asarray(member.frequency).shape[1] == len(atoms) * 3
+
+
+def test_shape_mismatch_across_members_raises(tmp_path):
+    atoms_a, second_a = _cu_second(tmp_path, 'a')
+    atoms_b, second_b = _cu_second(tmp_path, 'b')
+    m_a = PhononsEnsemble._member_from_second(
+        atoms_a, (2, 2, 2), second_a, symmetrize=False, phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory'))
+    m_b = PhononsEnsemble._member_from_second(
+        atoms_b, (2, 2, 2), second_b, symmetrize=False, phonons_kwargs=dict(kpts=(2, 2, 2), temperature=300, storage='memory'))
+    ens = PhononsEnsemble([m_a, m_b])
+    with pytest.raises(ValueError, match="disagree on the shape"):
+        ens.mean_std('frequency')

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -67,7 +67,8 @@ def _cu_second(tmp_path, folder):
 def test_member_from_second_builds_phonons(tmp_path):
     atoms, second = _cu_second(tmp_path, 'a')
     member = PhononsEnsemble._member_from_second(
-        atoms, (2, 2, 2), second, symmetrize=True, phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory')
+        atoms, (2, 2, 2), second, symmetrize=True,
+        phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory')
     )
     assert isinstance(member, Phonons)
     assert np.asarray(member.frequency).shape[1] == len(atoms) * 3
@@ -77,9 +78,11 @@ def test_shape_mismatch_across_members_raises(tmp_path):
     atoms_a, second_a = _cu_second(tmp_path, 'a')
     atoms_b, second_b = _cu_second(tmp_path, 'b')
     m_a = PhononsEnsemble._member_from_second(
-        atoms_a, (2, 2, 2), second_a, symmetrize=False, phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory'))
+        atoms_a, (2, 2, 2), second_a, symmetrize=False,
+        phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory'))
     m_b = PhononsEnsemble._member_from_second(
-        atoms_b, (2, 2, 2), second_b, symmetrize=False, phonons_kwargs=dict(kpts=(2, 2, 2), temperature=300, storage='memory'))
+        atoms_b, (2, 2, 2), second_b, symmetrize=False,
+        phonons_kwargs=dict(kpts=(2, 2, 2), temperature=300, storage='memory'))
     ens = PhononsEnsemble([m_a, m_b])
     with pytest.raises(ValueError, match="disagree on the shape"):
         ens.mean_std('frequency')

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -109,3 +109,38 @@ def test_from_calculators_empty_raises():
             atoms, (2, 2, 2), [], kpts=(3, 3, 3), temperature=300,
             storage='memory'
         )
+
+
+def _perturbed_second(atoms, base_second, scale, seed):
+    """Return a copy of base_second with symmetry-breaking noise on its value."""
+    from kaldo.observables.secondorder import SecondOrder
+    rng = np.random.default_rng(seed)
+    value = np.asarray(base_second.value).copy()
+    value = value + rng.normal(scale=scale, size=value.shape)
+    return SecondOrder.from_supercell(
+        atoms=atoms, supercell=(2, 2, 2), grid_type='C', value=value, is_acoustic_sum=False)
+
+
+def test_symmetrization_reduces_gamma_frequency_spread(tmp_path):
+    atoms, base_second = _cu_second(tmp_path, 'base')
+    seconds = [_perturbed_second(atoms, base_second, scale=1e-2, seed=s) for s in range(4)]
+
+    def build(symmetrize):
+        members = [PhononsEnsemble._member_from_second(
+            atoms, (2, 2, 2), s, symmetrize=symmetrize,
+            phonons_kwargs=dict(kpts=(3, 3, 3), temperature=300, storage='memory'))
+            for s in [_perturbed_second(atoms, base_second, scale=1e-2, seed=s) for s in range(4)]]
+        return PhononsEnsemble(members).std('frequency')
+
+    std_raw = build(symmetrize=False)
+    std_sym = build(symmetrize=True)
+    # Projection removes per-member symmetry violations, tightening the spread.
+    assert std_sym.sum() < std_raw.sum()
+
+
+def test_single_member_zero_std(tmp_path):
+    members = _cu_phonons(tmp_path, n=1)
+    ens = PhononsEnsemble(members)
+    assert ens.n_members == 1
+    _, std = ens.mean_std('frequency')
+    np.testing.assert_allclose(std, 0.0, atol=1e-12)

--- a/kaldo/tests/test_ensemble.py
+++ b/kaldo/tests/test_ensemble.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from kaldo.forceconstants import ForceConstants
+from kaldo.phonons import Phonons
+from kaldo.ensemble import PhononsEnsemble
+
+
+def _cu_phonons(tmp_path, n=1):
+    """Build n identical EMT Phonons for Cu (deterministic; std must be ~0)."""
+    atoms = bulk('Cu', 'fcc', a=3.61, cubic=True)
+    members = []
+    for i in range(n):
+        fc = ForceConstants(atoms=atoms, supercell=(2, 2, 2), folder=str(tmp_path / f'm{i}'))
+        fc.second.calculate(calculator=EMT(), delta_shift=1e-2, is_storing=False)
+        members.append(Phonons(forceconstants=fc, kpts=(3, 3, 3), temperature=300, storage='memory'))
+    return members
+
+
+def test_members_and_count(tmp_path):
+    members = _cu_phonons(tmp_path, n=2)
+    ens = PhononsEnsemble(members)
+    assert ens.n_members == 2
+    assert ens.members is members or list(ens.members) == members
+
+
+def test_empty_ensemble_raises():
+    with pytest.raises(ValueError, match="at least one member"):
+        PhononsEnsemble([])


### PR DESCRIPTION
Adds kaldo.PhononsEnsemble, a model-agnostic capability that aggregates harmonic phonon properties (mean and standard deviation) across an ensemble of committee members.

The primary entry point from_calculators runs a finite-difference second-order calculation per ASE calculator, projects each member onto the space-group-invariant subspace (the 2.2.0 symmetrization), builds a Phonons per member, and reduces any scalar per-mode property (frequency, heat_capacity, participation_ratio, bandwidth, ...) over the member axis via mean_std. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ensemble support for combining phonon calculations from multiple models or calculators.
  * Added mean, standard deviation, and combined statistics for per-mode phonon properties.
  * Added support for generating ensembles from independent finite-difference calculations.
  * Added optional force-constant symmetrization and isolated storage for ensemble members.

* **Bug Fixes**
  * Added validation for empty ensembles, unavailable properties, and mismatched data shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->