### PR TITLE
Fix classical free energy and document the hbar-scaling statistics design

### DIFF
--- a/kaldo/observables/harmonic_with_q_temp.py
+++ b/kaldo/observables/harmonic_with_q_temp.py
@@ -4,8 +4,28 @@ import ase.units as units
 from kaldo.storable import lazy_property, Storable
 
 
+# Classical statistics are implemented as a numerical hbar -> 0 limit: the
+# temperature-dependent observables evaluate the same quantum formulas with
+# hbar scaled by this factor, which pushes every occupation argument
+# x = hbar*omega/(k_B T) deep into the classical regime, where the quantum
+# expressions reduce to their classical limits with O(x^2) ~ 1e-12 error.
+# Consequences of the convention:
+#   * heat_capacity reduces to the Dulong-Petit k_B exactly;
+#   * population becomes the equipartition occupation k_B T/(hbar*omega),
+#     carrying a 1/CLASSICAL_HBAR_SCALE factor and a -1/2 offset from the
+#     Bose expansion 1/(e^x - 1) = 1/x - 1/2 + O(x). Both cancel where it
+#     matters: the offsets cancel in the scattering population factors
+#     (n' - n'') and 1/2(1 + n' + n''), and the 1/CLASSICAL_HBAR_SCALE
+#     cancels against the matching CLASSICAL_HBAR_SCALE applied to the
+#     scattering potential in
+#     Phonons._select_algorithm_for_phase_space_and_gamma. The population
+#     and phase_space arrays a user reads therefore carry this internal
+#     convention factor; bandwidth, heat capacity, and conductivity do not.
+CLASSICAL_HBAR_SCALE = 1e-6
+
+
 class HarmonicWithQTemp(hwq.HarmonicWithQ):
-    
+
     # Define storage formats for temperature-dependent harmonic properties
     # Inherits base _store_formats from HarmonicWithQ and adds temperature-specific ones
     _store_formats = {
@@ -21,7 +41,7 @@ class HarmonicWithQTemp(hwq.HarmonicWithQ):
         self.is_classic = is_classic
         self.hbar = units._hbar
         if self.is_classic:
-            self.hbar = self.hbar * 1e-6
+            self.hbar = self.hbar * CLASSICAL_HBAR_SCALE
 
     def _get_folder_path_components(self, label):
         components = []

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -12,7 +12,7 @@ from kaldo.helpers.logger import log_size
 from kaldo.storable import FOLDER_NAME
 from kaldo.grid import Grid
 from kaldo.observables.harmonic_with_q import HarmonicWithQ
-from kaldo.observables.harmonic_with_q_temp import HarmonicWithQTemp
+from kaldo.observables.harmonic_with_q_temp import HarmonicWithQTemp, CLASSICAL_HBAR_SCALE
 from kaldo.forceconstants import ForceConstants
 import kaldo.controllers.anharmonic as aha
 import tensorflow as tf
@@ -563,9 +563,6 @@ class Phonons(Storable):
         self.n_atoms = self.forceconstants.n_atoms
         self.n_modes = self.forceconstants.n_modes
         self.n_phonons = self.n_k_points * self.n_modes
-        self.hbar = units._hbar
-        if self.is_classic:
-            self.hbar = self.hbar * 1e-6
         self.g_factor = g_factor
         self.include_isotopes = include_isotopes
         self.iso_speed_up = iso_speed_up
@@ -878,8 +875,12 @@ class Phonons(Storable):
     def population(self):
         """
         Calculate the phonons population for each k point in k_points and each mode.
-        If classical, it returns the temperature divided by each frequency, using equipartition theorem.
-        If quantum it returns the Bose-Einstein distribution
+        If quantum, it returns the Bose-Einstein distribution.
+        If classical, it returns the equipartition occupation k_B*T/(hbar*omega)
+        scaled by the internal 1/CLASSICAL_HBAR_SCALE convention, minus 1/2
+        (see kaldo.observables.harmonic_with_q_temp); the convention factors
+        cancel in the scattering rates, so bandwidth and conductivity are
+        unaffected, but the array itself is not the physical occupation.
 
         Returns
         -------
@@ -904,19 +905,19 @@ class Phonons(Storable):
             population[ik] = phonon.population
         return population
 
-    @lazy_property(label='<temperature>')
+    @lazy_property(label='<temperature>/<statistics>')
     def free_energy(self):
         """
         Harmonic free energy, already Brillouin-zone averaged,
-        returned in eV per mode (including zero-point energy).
+        returned in eV per mode.
 
-        Formula: F = k_B * T * ln(1 - exp(-hbar*omega/(k_B*T))) + hbar*omega/2
+        Quantum: F = k_B * T * ln(1 - exp(-x)) + hbar*omega/2, with
+        x = hbar*omega/(k_B*T), including zero-point energy.
 
-        where:
-            k_B: Boltzmann constant
-            T: temperature
-            hbar: reduced Planck constant
-            omega: angular frequency (2*pi*frequency)
+        Classical (``is_classic=True``): F = k_B * T * ln(x), the x -> 0
+        limit of the quantum expression (the zero-point term cancels
+        against the expansion of the logarithm). It uses the physical hbar
+        as the phase-space measure and contains no zero-point energy.
 
         Returns
         -------
@@ -927,12 +928,14 @@ class Phonons(Storable):
 
         Notes
         -----
-        - At T=0, only the zero-point energy contributes (thermal term vanishes)
+        - At T=0, the quantum result reduces to the zero-point energy; the
+          classical result reduces to its T -> 0 limit, zero
         - Modes with imaginary frequencies (negative frequency values) are automatically
           excluded and will trigger a warning, as they may indicate structural instability
         """
-        # At T=0, F = ZPE only (thermal contribution vanishes)
         if self.temperature == 0:
+            if self.is_classic:
+                return np.zeros_like(self.frequency)
             return self.zero_point_harmonic_energy
 
         # Check for imaginary frequencies (negative values)
@@ -952,6 +955,12 @@ class Phonons(Storable):
         # This avoids both log(0) for low frequencies and log(negative) for imaginary frequencies
         physical = self.physical_mode.reshape(self.frequency.shape)
         valid_modes = physical & (self.frequency > 0)
+
+        if self.is_classic:
+            ln_term[valid_modes] = np.log(x_vals[valid_modes])
+            f_cell = 1.0 / units._e * units._k * self.temperature * ln_term
+            return f_cell / self.n_k_points
+
         ln_term[valid_modes] = np.log1p(-np.exp(-x_vals[valid_modes]))  # ln(1 − e^{-x})
 
         # Thermal contribution: k_B*T*ln(1 - exp(-hbar*omega/(k_B*T))) in eV
@@ -969,6 +978,10 @@ class Phonons(Storable):
         """
         Harmonic zero-point energy, Brillouin-zone averaged,
         returned in eV per mode.
+
+        This is a quantum quantity (hbar*omega/2); it has no classical
+        counterpart and ``free_energy`` with ``is_classic=True`` does not
+        include it.
         """
         zpe_cell = 0.5 * units._hbar * self.frequency * 2.0 * np.pi * 1.0e12 / units._e
         return zpe_cell / self.n_k_points
@@ -1035,6 +1048,11 @@ class Phonons(Storable):
     def phase_space(self):
         """
         Calculate the 3-phonons-processes phase_space, for each k point in k_points and each mode.
+
+        With ``is_classic=True`` the values carry the internal
+        1/CLASSICAL_HBAR_SCALE population convention (see
+        kaldo.observables.harmonic_with_q_temp), so classical and quantum
+        phase spaces are not directly comparable in magnitude.
 
         Returns
         -------
@@ -1439,8 +1457,10 @@ class Phonons(Storable):
         # Reshape population to 1D for unified indexing
         population_flat = self.population.flatten()
 
-        # Apply hbar scaling factor for classical vs quantum
-        hbar_factor = 1e-6 if self.is_classic else 1
+        # Classical statistics: cancel the 1/CLASSICAL_HBAR_SCALE the
+        # population carries (see harmonic_with_q_temp.CLASSICAL_HBAR_SCALE)
+        # by scaling the potential with the matching factor.
+        hbar_factor = CLASSICAL_HBAR_SCALE if self.is_classic else 1
 
         ps_and_gamma = aha.calculate_ps_and_gamma(
             self.sparse_phase,

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -933,7 +933,8 @@ class Phonons(Storable):
         - Modes with imaginary frequencies (negative frequency values) are automatically
           excluded and will trigger a warning, as they may indicate structural instability
         """
-        if self.temperature == 0:
+        # atol: any temperature below 1e-12 K is physically zero
+        if np.isclose(self.temperature, 0.0, rtol=0.0, atol=1e-12):
             if self.is_classic:
                 return np.zeros_like(self.frequency)
             return self.zero_point_harmonic_energy

--- a/kaldo/tests/test_quantum_classic_cache.py
+++ b/kaldo/tests/test_quantum_classic_cache.py
@@ -80,3 +80,78 @@ def test_quantum_then_classic_cache():
         # Clean up temporary directory
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir)
+
+
+def test_free_energy_statistics(tmp_path):
+    """Classical free energy must differ from quantum and cache separately.
+
+    Regression: free_energy ignored is_classic (always the quantum formula)
+    and its cache label lacked <statistics>, so quantum and classical runs
+    shared a storage path. The classical formula is F = k_B T ln(x) with
+    x = hbar*omega/(k_B T), the x -> 0 limit of the quantum
+    F = k_B T ln(1 - exp(-x)) + hbar*omega/2 (the zero-point term cancels
+    against the expansion of the logarithm); it uses the physical hbar and
+    contains no zero-point energy.
+    """
+    import ase.units as units
+
+    forceconstants = ForceConstants.from_folder(
+        folder="kaldo/tests/si-crystal", supercell=[3, 3, 3], format="eskm"
+    )
+    kwargs = dict(forceconstants=forceconstants, kpts=[3, 3, 3],
+                  storage="formatted", folder=str(tmp_path))
+
+    # Quantum first, same folder: without <statistics> in the label the
+    # classical run below would silently read this cache.
+    ph_q = Phonons(is_classic=False, temperature=300, **kwargs)
+    f_q = ph_q.free_energy
+
+    ph_c = Phonons(is_classic=True, temperature=300, **kwargs)
+    f_c = ph_c.free_energy
+
+    frequency = ph_c.frequency
+    physical = ph_c.physical_mode.reshape(frequency.shape) & (frequency > 0)
+    x = units._hbar * frequency * 2.0 * np.pi * 1.0e12 / (units._k * 300.0)
+    kT_eV = units._k * 300.0 / units._e
+
+    expected = np.zeros_like(x)
+    expected[physical] = kT_eV * np.log(x[physical])
+    expected /= ph_c.n_k_points
+    np.testing.assert_allclose(f_c, expected, rtol=1e-10, atol=1e-16)
+
+    # And the quantum cache must have stayed quantum.
+    assert not np.allclose(f_q, f_c, rtol=1e-3)
+    np.testing.assert_allclose(ph_q.free_energy, f_q, rtol=0, atol=0)
+
+
+def test_free_energy_quantum_minus_classical_is_wigner_correction(tmp_path):
+    """Independent physics cross-check of both statistics branches.
+
+    In the high-temperature regime the quantum and classical harmonic free
+    energies differ by the leading Wigner correction,
+    F_q - F_cl = (hbar*omega)^2 / (24 k_B T) per mode, with relative
+    corrections of O(x^2). At 2000 K silicon's stiffest mode has x ~ 0.4,
+    so the identity holds to a few parts in 1e3. A wrong hbar convention,
+    a surviving zero-point term, or a sign slip in either branch breaks
+    this by orders of magnitude.
+    """
+    import ase.units as units
+
+    forceconstants = ForceConstants.from_folder(
+        folder="kaldo/tests/si-crystal", supercell=[3, 3, 3], format="eskm"
+    )
+    temperature = 2000.0
+    kwargs = dict(forceconstants=forceconstants, kpts=[3, 3, 3],
+                  temperature=temperature, storage="memory")
+
+    f_q = Phonons(is_classic=False, **kwargs).free_energy
+    ph_c = Phonons(is_classic=True, **kwargs)
+    f_c = ph_c.free_energy
+
+    frequency = ph_c.frequency
+    physical = ph_c.physical_mode.reshape(frequency.shape) & (frequency > 0)
+    x = units._hbar * frequency * 2.0 * np.pi * 1.0e12 / (units._k * temperature)
+    kT_eV = units._k * temperature / units._e
+
+    wigner = (x[physical] ** 2 / 24.0) * kT_eV / ph_c.n_k_points
+    np.testing.assert_allclose((f_q - f_c)[physical], wigner, rtol=5e-3)


### PR DESCRIPTION
## Context

Deep review of `is_classic`. The core design is a numerical hbar -> 0 limit: temperature-dependent observables evaluate the quantum formulas with hbar scaled by 1e-6, pushing every occupation into the classical regime with O(x^2) ~ 1e-12 error. The review verified the mechanism end to end: classical heat capacity equals Dulong-Petit k_B to 1e-10, the population offsets cancel exactly in the scattering factors (the two -1/2 offsets cancel the spontaneous +1 in the emission term), the true hbar reaches the scattering prefactor while the 1e-6 enters exactly once and cancels the population's 1e6, and classical bandwidths are strictly linear in T (measured Gamma(600K)/Gamma(300K) = 2.000000 across all modes). The validated physics is untouched by this PR.

## The bug

`free_energy` ignored `is_classic`: QHA classical runs (`quasiharmonic.py` passes the flag and reads this property) silently computed the quantum formula, zero-point energy included. Compounding it, the cache label was `<temperature>` without `<statistics>`, so quantum and classical runs shared a storage path, the exact collision `test_quantum_classic_cache` guards for other properties.

## The fix

- Classical branch: F = k_B T ln(hbar omega / k_B T), the x -> 0 limit of the quantum expression (the zero-point term cancels against the expansion of the logarithm); physical hbar as phase-space measure, no ZPE, T=0 returns the limit value zero.
- Label is now `<temperature>/<statistics>`, consistent with every other statistics-dependent property. Existing quantum caches migrate paths once (one cheap harmonic recompute); existing classical caches contained quantum values and deserve invalidation.
- Two regression tests: the formula + cache-separation pin, and an independent physics cross-check asserting F_quantum - F_classical equals the leading Wigner correction (hbar omega)^2/(24 k_B T) at 2000 K to a few parts in 1e3. A wrong hbar convention, surviving ZPE, or sign slip in either branch breaks the latter by orders of magnitude.

## Cleanup (no behavior change)

- Deleted `Phonons.hbar`, a classically-scaled copy with zero consumers.
- Named the magic constant (`CLASSICAL_HBAR_SCALE` in `harmonic_with_q_temp`, imported by `phonons`) and documented the design at its definition: why heat capacity lands exactly on Dulong-Petit, where the population's 1/CLASSICAL_HBAR_SCALE factor and -1/2 offset cancel, and which public arrays carry the convention.
- Corrected the `population` docstring (the stored array is 1e6-scaled equipartition minus 1/2, not "temperature divided by frequency") and added the convention note to `phase_space` and a quantum-only note to `zero_point_harmonic_energy`. Documented rather than rescaled: rescaling would perturb the validated scattering pipeline for zero physics gain.

## Testing

35 passed: quantum/classic cache (including the 2 new tests), amorphous classical QHGK (the MD-validated pinned numbers, unchanged), quasiharmonic, crystal, broadening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of classical vs quantum statistical conventions.
  - Classical free energy now correctly handles “zero” temperature (returns zero) and uses the correct classical logarithm form.
  - Quantum free energy continues to include zero-point energy where applicable.
  - Better separation of classical and quantum cached results.
  - Updated classical scaling used in the phase-space and scattering-rate calculations.

- **Tests**
  - Added regression tests covering classical/quantum free-energy correctness, cache reuse, and the high-temperature quantum-minus-classical (Wigner) correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->