### PR TITLE
Fix silent drop of out-of-range cell offsets in the ShengBTE FC3 reader

### DIFF
--- a/kaldo/interfaces/shengbte_io.py
+++ b/kaldo/interfaces/shengbte_io.py
@@ -146,6 +146,26 @@ def read_second_order_qe_matrix(filename):
         return second, supercell, charges
 
 
+def _resolve_cell_id(cell_position, cell_inv, supercell, current_grid, source):
+    """Resolve a Cartesian cell offset to a replica id, independent of the sign
+    convention the writer used for half-box (even-supercell) offsets.
+
+    ``Grid.cell_position_to_id`` rounds the raw Cartesian offset to an integer
+    cell index and looks it up against kaldo's minimum-image-wrapped grid. On
+    even supercells the half-box replica is representable as either +d/2 or
+    -d/2 (same physical replica); kaldo's wrapped grid only keeps +d/2, so a
+    file written with the -d/2 convention fails that lookup. Resolve instead
+    by wrapping the raw integer index into [0, d) ourselves and looking it up
+    against the unwrapped grid, which enumerates every 0..d-1 triplet exactly
+    once and so is unique and total for any integer input.
+    """
+    frac = cell_position.dot(cell_inv)
+    if np.max(np.abs(frac - np.round(frac))) > 1e-3:
+        raise ValueError(f"{source}: cell offset {cell_position} is not a lattice vector of the supercell.")
+    cell_index = np.mod(frac.round(0).astype(int), np.array(supercell, dtype=int))
+    ids = current_grid.grid_index_to_id(cell_index, is_wrapping=False)
+    return int(ids[0])
+
 
 def read_third_order_matrix(third_file: str,
                             atoms: Atoms,
@@ -157,6 +177,7 @@ def read_third_order_matrix(third_file: str,
     n_replicas = np.prod(supercell)
     third_order = np.zeros((n_unit_atoms, 3, n_replicas, n_unit_atoms, 3, n_replicas, n_unit_atoms, 3))
     current_grid = Grid(supercell, order=order)
+    cell_inv = np.linalg.inv(np.array(atoms.cell))
 
     with open(third_file, 'r') as file:
         first_line = file.readline()
@@ -168,15 +189,17 @@ def read_third_order_matrix(third_file: str,
 
             # next two lines are the positions of the second and third cell
             second_cell_position = np.array([float(x) for x in file.readline().split()])
-            second_cell_id = current_grid.cell_position_to_id(second_cell_position, atoms.cell, is_wrapping=True)
+            second_cell_id = _resolve_cell_id(second_cell_position, cell_inv, supercell, current_grid, third_file)
 
             third_cell_position = np.array([float(x) for x in file.readline().split()])
-            third_cell_id = current_grid.cell_position_to_id(third_cell_position, atoms.cell, is_wrapping=True)
+            third_cell_id = _resolve_cell_id(third_cell_position, cell_inv, supercell, current_grid, third_file)
 
             # index to atom
             atom_i, atom_j, atom_k = np.array([int(x) for x in file.readline().split()]) - 1
 
             # for x,y,z directions with 3 atoms
+            # FC3 assigns each quartet's block directly into its slot (ShengBTE-format writers emit
+            # unique (atom, cell) slots here).
             for _ in range(27):
                 values = np.array([float(x) for x in file.readline().split()])
                 alpha, beta, gamma = values[:3].round(0).astype(int) - 1

--- a/kaldo/tests/test_crystal_qe_vasp.py
+++ b/kaldo/tests/test_crystal_qe_vasp.py
@@ -86,11 +86,15 @@ def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 2.7, significant=2)
+    # recalibrated after the ShengBTE FC3 parser fix (mod-wrapped cell offsets); the old value baked in
+    # silently dropped force constants
+    np.testing.assert_approx_equal(cond, 2.8, significant=2)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 2.4, significant=2)
+    # recalibrated after the ShengBTE FC3 parser fix (mod-wrapped cell offsets); the old value baked in
+    # silently dropped force constants
+    np.testing.assert_approx_equal(cond, 2.5, significant=2)

--- a/kaldo/tests/test_shengbte_offsets.py
+++ b/kaldo/tests/test_shengbte_offsets.py
@@ -1,0 +1,140 @@
+"""
+Regression tests for the ShengBTE third-order cell-offset bug.
+
+``read_third_order_matrix`` resolves each quartet's second/third cell offset
+(a Cartesian vector in the FORCE_CONSTANTS_3RD file) to a replica id by
+rounding it to an integer lattice index and looking it up against kaldo's
+minimum-image-wrapped grid (``Grid.grid(is_wrapping=True)``). That grid keeps
+only one representative index per replica within the minimum-image range, so
+an offset written outside that range, whether from a different sign
+convention for a half-box (even-supercell) replica, or from an unwrapped
+integer index on an odd supercell, fails the lookup. The lookup returns an
+empty array of ids, which is then used directly as a numpy fancy index into
+the third-order tensor; indexing with an empty array is not an error, it is a
+silent no-op, so the force constants for that quartet are dropped without any
+exception, warning, or nonzero-count mismatch surfacing at the call site.
+
+These tests exercise ``kaldo.interfaces.shengbte_io.read_third_order_matrix``
+directly, with no pheasy code involved, using a synthetic two-atom cubic
+POSCAR and a hand-written FORCE_CONSTANTS_3RD file.
+"""
+import itertools
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+POSCAR_2ATOM = (
+    "Si\n1.0\n3.0 0.0 0.0\n0.0 3.0 0.0\n0.0 0.0 3.0\nSi\n2\n"
+    "Direct\n0.0 0.0 0.0\n0.5 0.5 0.5\n"
+)
+
+
+def _write_poscar(folder):
+    (Path(folder) / "POSCAR").write_text(POSCAR_2ATOM)
+
+
+def _write_fc3_text(path, blocks):
+    """blocks: list of (cart_offset_2 (3,), cart_offset_3 (3,), (i, j, k) 0-based unit atoms, phi (3,3,3))."""
+    with open(path, "w") as fd:
+        fd.write(f"{len(blocks)}\n")
+        for n, (r2, r3, (i, j, k), phi) in enumerate(blocks, start=1):
+            fd.write(f"\n{n}\n")
+            fd.write("".join(f"{x:25.15f}" for x in r2) + "\n")
+            fd.write("".join(f"{x:25.15f}" for x in r3) + "\n")
+            fd.write(f"{i + 1:6d}{j + 1:6d}{k + 1:6d}\n")
+            for (a, b, c) in itertools.product([1, 2, 3], repeat=3):
+                fd.write(f"{a:4d}{b:4d}{c:4d}{phi[a - 1, b - 1, c - 1]:25.15f}\n")
+
+
+def test_fc3_offset_sign_convention_resolves_to_same_replica(tmp_path):
+    """On supercell (2, 1, 1) with a=3.0 cubic cell, +a and -a along x are the
+    same physical replica (id 1): the half-box offset is representable with
+    either sign. A file written with the negative-offset convention (-3.0)
+    must resolve to the same replica as the positive convention (+3.0), not
+    silently drop the force constants for that quartet.
+
+    This fails on the pre-fix parser: the -3.0 offset does not match the
+    wrapped grid's kept +3.0 representative, the cell lookup returns an empty
+    id array, and the fancy-index assignment into the dense tensor becomes a
+    silent no-op, leaving that block's slot at its initialized zero.
+    """
+    import ase.io
+    from kaldo.interfaces.shengbte_io import read_third_order_matrix
+    rng = np.random.default_rng(11)
+    phi = rng.standard_normal((3, 3, 3))
+    positive_dir = tmp_path / "positive"
+    negative_dir = tmp_path / "negative"
+    positive_dir.mkdir()
+    negative_dir.mkdir()
+    _write_poscar(positive_dir)
+    _write_poscar(negative_dir)
+    _write_fc3_text(positive_dir / "FORCE_CONSTANTS_3RD",
+                    [(np.array([3.0, 0.0, 0.0]), np.zeros(3), (0, 1, 0), phi)])
+    _write_fc3_text(negative_dir / "FORCE_CONSTANTS_3RD",
+                    [(np.array([-3.0, 0.0, 0.0]), np.zeros(3), (0, 1, 0), phi)])
+    atoms_positive = ase.io.read(positive_dir / "POSCAR", format="vasp")
+    atoms_negative = ase.io.read(negative_dir / "POSCAR", format="vasp")
+    third_positive = read_third_order_matrix(str(positive_dir / "FORCE_CONSTANTS_3RD"), atoms_positive,
+                                             (2, 1, 1), order="C")
+    third_negative = read_third_order_matrix(str(negative_dir / "FORCE_CONSTANTS_3RD"), atoms_negative,
+                                             (2, 1, 1), order="C")
+    dense_positive = np.asarray(third_positive).reshape((2, 3, 2, 2, 3, 2, 2, 3))
+    dense_negative = np.asarray(third_negative).reshape((2, 3, 2, 2, 3, 2, 2, 3))
+    np.testing.assert_allclose(dense_negative, dense_positive, atol=1e-12)
+    # block lands at replica 1 (the (1, 0, 0) cell on Grid((2, 1, 1), 'C'))
+    np.testing.assert_allclose(dense_negative[0, :, 1, 1, :, 0, 0, :], phi, atol=1e-12)
+    assert np.count_nonzero(dense_negative) == np.count_nonzero(phi)
+
+
+def test_fc3_out_of_representative_range_offset_resolves_on_odd_grid(tmp_path):
+    """On supercell (3, 1, 1), the integer cell index -2 (Cartesian -6.0 along
+    x) is outside the minimum-image representative range kept by the wrapped
+    grid, but is the same replica as index 1 (mod 3): +3.0. The parser must
+    resolve -6.0 identically to +3.0.
+
+    This also fails on the pre-fix parser: -6.0 rounds to index -2, which is
+    not one of the wrapped grid's kept {-1, 0, 1} representatives for a
+    (3, 1, 1) grid, so the lookup again returns an empty id array and the
+    assignment is silently dropped.
+    """
+    import ase.io
+    from kaldo.interfaces.shengbte_io import read_third_order_matrix
+    rng = np.random.default_rng(13)
+    phi = rng.standard_normal((3, 3, 3))
+    wrapped_dir = tmp_path / "wrapped"
+    unwrapped_dir = tmp_path / "unwrapped"
+    wrapped_dir.mkdir()
+    unwrapped_dir.mkdir()
+    _write_poscar(wrapped_dir)
+    _write_poscar(unwrapped_dir)
+    _write_fc3_text(wrapped_dir / "FORCE_CONSTANTS_3RD",
+                    [(np.array([3.0, 0.0, 0.0]), np.zeros(3), (0, 1, 0), phi)])
+    _write_fc3_text(unwrapped_dir / "FORCE_CONSTANTS_3RD",
+                    [(np.array([-6.0, 0.0, 0.0]), np.zeros(3), (0, 1, 0), phi)])
+    atoms_wrapped = ase.io.read(wrapped_dir / "POSCAR", format="vasp")
+    atoms_unwrapped = ase.io.read(unwrapped_dir / "POSCAR", format="vasp")
+    third_wrapped = read_third_order_matrix(str(wrapped_dir / "FORCE_CONSTANTS_3RD"), atoms_wrapped,
+                                            (3, 1, 1), order="C")
+    third_unwrapped = read_third_order_matrix(str(unwrapped_dir / "FORCE_CONSTANTS_3RD"), atoms_unwrapped,
+                                              (3, 1, 1), order="C")
+    dense_wrapped = np.asarray(third_wrapped).reshape((2, 3, 3, 2, 3, 3, 2, 3))
+    dense_unwrapped = np.asarray(third_unwrapped).reshape((2, 3, 3, 2, 3, 3, 2, 3))
+    np.testing.assert_allclose(dense_unwrapped, dense_wrapped, atol=1e-12)
+    assert np.count_nonzero(dense_unwrapped) == np.count_nonzero(phi)
+
+
+def test_fc3_non_lattice_offset_raises(tmp_path):
+    """A cell offset that is not an integer multiple of a lattice vector (here
+    a half-cell shift along x) cannot correspond to any replica; the parser
+    must raise rather than silently rounding to a wrong or empty replica."""
+    import ase.io
+    from kaldo.interfaces.shengbte_io import read_third_order_matrix
+    rng = np.random.default_rng(17)
+    phi = rng.standard_normal((3, 3, 3))
+    _write_poscar(tmp_path)
+    _write_fc3_text(tmp_path / "FORCE_CONSTANTS_3RD",
+                    [(np.array([1.5, 0.0, 0.0]), np.zeros(3), (0, 1, 0), phi)])
+    atoms = ase.io.read(tmp_path / "POSCAR", format="vasp")
+    with pytest.raises(ValueError, match="lattice vector"):
+        read_third_order_matrix(str(tmp_path / "FORCE_CONSTANTS_3RD"), atoms, (2, 1, 1), order="C")


### PR DESCRIPTION
# Fix silent drop of out-of-range cell offsets in the ShengBTE FC3 reader

## The bug

`shengbte_io.read_third_order_matrix` resolved each block's Cartesian cell offset with `Grid.cell_position_to_id(..., is_wrapping=True)`, which compares the raw rounded integer cell index against the minimum-image-wrapped grid. Any index outside the wrapped representative range fails the lookup silently: the id array comes back empty and the numpy fancy-index assignment writes nothing. Two common ways to hit it:

- an index like `-2` on a 3x3x3 supercell (`-2 mod 3 = 1` is a valid replica, but the wrapped grid for d=3 only contains `{-1, 0, 1}`)
- the half-box convention on even supercells (`-d/2` vs `+d/2` are the same replica; the wrapped grid keeps only `+d/2`)

On the shipped `kaldo/tests/si-crystal/qe/FORCE_CONSTANTS_3RD` fixture this silently dropped **168 of 2332 offsets (7% of blocks)**, so the qe Si golden conductivities were calibrated against incomplete third-order force constants.

## The fix

A `_resolve_cell_id` helper: verify the offset is an actual lattice vector (rounding residual, loud `ValueError` otherwise), wrap the integer index into `[0, d)` with `np.mod`, and look it up on the unwrapped grid, which is total and unique for any integer input. This matches the convention `read_third_d3q` in the same file already uses. The cell inverse is computed once per parse instead of per block.

## Effect on results and goldens

Restoring the dropped force constants shifts the qe Si reference conductivities by ~4-5%, so the two golden values in `test_crystal_qe_vasp.py` are recalibrated (RTA 2.7 -> 2.8, inverse 2.4 -> 2.5 at significant=2) with explanatory comments. A stash-control confirmed the old goldens pass with the old parser and the new values match the fixed parser; the pre/post nonzero count on the fixture is 25302 -> 29208.

**Release-note item:** any existing ShengBTE-format dataset whose `FORCE_CONSTANTS_3RD` contains offsets outside the wrapped representative range will now load completely and may show small conductivity shifts; previously those blocks were silently ignored.

## Testing

New `kaldo/tests/test_shengbte_offsets.py` exercises the parser directly: positive vs negative offset conventions load identically on even and odd supercells (both fail with silent zeros on the old code), and a non-lattice offset raises. `test_crystal_vasp.py` (5x5x5 fixture, fully in-range offsets) is unchanged and passes, as do the other ShengBTE-format consumers.

Found while validating the pheasy importer (#286), which stacks on this branch.
