### PR TITLE
Fix imaginary-mode ZPE poisoning and QHA hygiene; test classical QHA

### DIFF
--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -954,8 +954,7 @@ class Phonons(Storable):
 
         # Only calculate for physical modes with positive frequencies
         # This avoids both log(0) for low frequencies and log(negative) for imaginary frequencies
-        physical = self.physical_mode.reshape(self.frequency.shape)
-        valid_modes = physical & (self.frequency > 0)
+        valid_modes = self._thermodynamic_modes
 
         if self.is_classic:
             ln_term[valid_modes] = np.log(x_vals[valid_modes])
@@ -974,6 +973,14 @@ class Phonons(Storable):
         f_cell = thermal_part_eV + zpe_part
         return f_cell / self.n_k_points
 
+    @property
+    def _thermodynamic_modes(self):
+        """Boolean mask of modes that enter the thermodynamic sums:
+        physical modes with positive (real) frequencies. Shared by
+        free_energy and zero_point_harmonic_energy so their exclusions
+        cannot diverge."""
+        return self.physical_mode.reshape(self.frequency.shape) & (self.frequency > 0)
+
     @lazy_property(label='')
     def zero_point_harmonic_energy(self):
         """
@@ -990,7 +997,7 @@ class Phonons(Storable):
         include it.
         """
         zpe_cell = np.zeros_like(self.frequency)
-        valid = self.physical_mode.reshape(self.frequency.shape) & (self.frequency > 0)
+        valid = self._thermodynamic_modes
         zpe_cell[valid] = 0.5 * units._hbar * self.frequency[valid] * 2.0 * np.pi * 1.0e12 / units._e
         return zpe_cell / self.n_k_points
 

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -980,11 +980,18 @@ class Phonons(Storable):
         Harmonic zero-point energy, Brillouin-zone averaged,
         returned in eV per mode.
 
+        Non-physical modes and modes with imaginary (negative) frequencies
+        contribute zero, matching the ``free_energy`` contract; summing
+        hbar*omega/2 over imaginary modes would otherwise poison the total
+        with negative spurious contributions on unstable structures.
+
         This is a quantum quantity (hbar*omega/2); it has no classical
         counterpart and ``free_energy`` with ``is_classic=True`` does not
         include it.
         """
-        zpe_cell = 0.5 * units._hbar * self.frequency * 2.0 * np.pi * 1.0e12 / units._e
+        zpe_cell = np.zeros_like(self.frequency)
+        valid = self.physical_mode.reshape(self.frequency.shape) & (self.frequency > 0)
+        zpe_cell[valid] = 0.5 * units._hbar * self.frequency[valid] * 2.0 * np.pi * 1.0e12 / units._e
         return zpe_cell / self.n_k_points
 
 

--- a/kaldo/quasiharmonic.py
+++ b/kaldo/quasiharmonic.py
@@ -511,11 +511,13 @@ def calculate_qha(atoms, calculator, temperatures,
         fc_config = {
             'atoms': atoms_scaled,
             'supercell': supercell,
-            'folder': f'{folder}/fcs_{i_grid}'
+            'folder': f'{folder}/fcs_{i_grid}',
+            'is_acoustic_sum': True
         }
         force_constants = ForceConstants(**fc_config)
-        force_constants.second.is_acoustic_sum = True
-        force_constants.second.calculate(calculator, delta_shift=1e-4)
+        # Honor storage='memory': don't persist force constants either
+        force_constants.second.calculate(calculator, delta_shift=1e-4,
+                                         is_storing=(storage != 'memory'))
 
         # Calculate vibrational free energy for each temperature
         for i_temp, temp in enumerate(temperatures):
@@ -541,7 +543,6 @@ def calculate_qha(atoms, calculator, temperatures,
                 potential_energy + vibrational_free_energy
             )
 
-    np.save('raw_free_energy.npy', free_energy_matrix)
     # Fit and find minimum for each temperature
     logging.info("Fitting polynomials and finding minima...")
     lattice_constants = []

--- a/kaldo/tests/test_quasiharmonic.py
+++ b/kaldo/tests/test_quasiharmonic.py
@@ -270,6 +270,54 @@ class TestCalculateQHA:
         assert np.allclose(loaded_data['free_energies'], results['free_energies'])
         assert loaded_data['symmetry'] == results['symmetry']
 
+    def test_calculate_qha_classical_vs_quantum(self, tmp_path, monkeypatch):
+        """End-to-end classical QHA: statistics reach the free-energy surface.
+
+        Physics pin: the quantum harmonic free energy exceeds the classical
+        one for every mode (zero-point energy at T=0, the Wigner correction
+        at finite T), and the potential-energy surface is
+        statistics-independent, so F_classical < F_quantum must hold at
+        every grid point and temperature. On this deliberately unstable
+        fixture (simple-cubic Cu has imaginary modes) the bound is also a
+        regression test for the zero-point energy summing 0.5*hbar*omega
+        over imaginary modes, which poisoned the quantum branch with
+        negative spurious contributions and inverted the bound.
+
+        Also pins the no-pollution contract: with storage='memory' a QHA run
+        must not write anything to the working directory (regression for the
+        unconditional raw_free_energy.npy dump and the force-constant folder
+        that ignored the memory storage setting).
+        """
+        monkeypatch.chdir(tmp_path)
+        atoms = bulk("Cu", "sc", a=3.6, cubic=True)
+
+        common = dict(
+            atoms=atoms,
+            calculator=EMT(),
+            temperatures=[0, 300],
+            supercell=(2, 2, 2),
+            kpts=(3, 3, 3),
+            symmetry='cubic',
+            n_lattice_points=3,
+            storage='memory',
+        )
+        results_q = calculate_qha(is_classic=False, **common)
+        results_c = calculate_qha(is_classic=True, **common)
+
+        assert results_c['free_energies'].shape == (2,)
+        # The bound is asserted on the raw grid values: the polynomial fit
+        # behind 'free_energies' is a ridge regression, which is not
+        # guaranteed to preserve pointwise ordering.
+        matrix_q = results_q['free_energy_matrix']
+        matrix_c = results_c['free_energy_matrix']
+        assert (matrix_c < matrix_q).all(), (
+            "classical free energy must lie below quantum at every grid point "
+            f"and temperature (classical {matrix_c}, quantum {matrix_q})"
+        )
+
+        leftovers = sorted(p.name for p in tmp_path.iterdir())
+        assert leftovers == [], f"QHA with storage='memory' wrote to the working directory: {leftovers}"
+
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
## Context

Follow-up to #287: adding the missing end-to-end classical QHA coverage. The new test's physics bound immediately caught a real pre-existing bug.

## The bug the new test found

`zero_point_harmonic_energy` summed 0.5 hbar omega over **all** modes, imaginary (negative-frequency) ones included, while `free_energy`'s thermal term masks them. On unstable structures the quantum free energy inherits spurious **negative** zero-point contributions through its ZPE term. The QHA test fixture (simple-cubic Cu under EMT) is mechanically unstable, and the poisoning was large enough (-12.5 meV/atom) to push the quantum free energy **below** the classical one, violating the exact per-mode bound F_quantum > F_classical (ZPE at T=0, Wigner correction at finite T). All #287 validation ran on stable Si, where every frequency is positive, so it was structurally blind to this.

**Fix**: mask the ZPE to physical positive-frequency modes, matching the documented `free_energy` contract. Stable structures change only at the Gamma-acoustic level (~1e-21 eV), far below every pinned reference (verified: full statistics + amorphous-classical + crystal battery unchanged).

## QHA hygiene (found while adding coverage)

- **Deleted** the unconditional `np.save('raw_free_energy.npy', ...)`: it wrote to the current working directory on every QHA run and has zero consumers anywhere; the matrix is already in the returned dict and in `save_qha_results`.
- **`storage='memory'` now honored end to end**: the force-constant step wrote `fcs_*` folders to disk even when the caller asked for memory-only storage (this plus the npy dump is exactly the stray-file pollution we kept seeing in the repo root during test runs).
- `is_acoustic_sum` passes through the `ForceConstants` constructor (#276) instead of being set post-construction.

## The new test

Classical vs quantum QHA end to end on the deliberately unstable fixture, asserting F_classical < F_quantum at every grid point and temperature. The bound is checked on the raw `free_energy_matrix`: the ridge fit behind the minimized `free_energies` is not guaranteed to preserve pointwise ordering (worth a separate look someday; out of scope here). A second assertion pins the no-pollution contract: a `storage='memory'` run leaves the working directory untouched. TDD: the test fails on main both through the physics bound (ZPE bug) and the pollution pin.

## Testing

28 passed: full QHA suite (including the new test), the #287 statistics tests, the MD-validated amorphous classical pins, and the crystal smoke suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-point energy calculations now exclude non-physical modes and imaginary frequencies.
  * Quasiharmonic calculations with in-memory storage no longer persist intermediate force constants or generate unnecessary files.
  * Classical vs. quantum free-energy results now follow the expected pointwise ordering.
* **Tests**
  * Added an end-to-end regression test comparing classical and quantum quasiharmonic free-energy grids.
  * Added verification that in-memory runs leave no files or folders behind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->