### PR TITLE
Repin transport regressions on gauge-invariant configurations

### DIFF
--- a/kaldo/tests/test_broadening_shapes_crystal.py
+++ b/kaldo/tests/test_broadening_shapes_crystal.py
@@ -21,6 +21,7 @@ def phonons():
         kpts=[5, 5, 5],
         is_classic=False,
         temperature=300,
+        broadening_kernel="tdep",  # gauge-invariant sigma; the shapes are what these tests probe (#290)
         storage="memory",
     )
     return phonons
@@ -28,14 +29,14 @@ def phonons():
 
 def test_triangle_broadening(phonons):
     phonons.broadening_shape = "triangle"
-    np.testing.assert_approx_equal(phonons.bandwidth[0][3], 0.10344, significant=4)
+    np.testing.assert_allclose(np.mean(phonons.bandwidth[0][3:6]), 0.331071, rtol=1e-3, atol=0.0)
 
 
 def test_gaussian_broadening(phonons):
     phonons.broadening_shape = "gauss"
-    np.testing.assert_approx_equal(phonons.bandwidth[0][3], 0.12086, significant=4)
+    np.testing.assert_allclose(np.mean(phonons.bandwidth[0][3:6]), 0.467721, rtol=1e-3, atol=0.0)
 
 
 def test_lorentz_broadening(phonons):
     phonons.broadening_shape = "lorentz"
-    np.testing.assert_approx_equal(phonons.bandwidth[0][3], 0.09793, significant=4)
+    np.testing.assert_allclose(np.mean(phonons.bandwidth[0][3:6]), 0.364596, rtol=1e-3, atol=0.0)

--- a/kaldo/tests/test_crystal.py
+++ b/kaldo/tests/test_crystal.py
@@ -1,5 +1,15 @@
 """
 Unit and regression test for the kaldo package.
+
+This file is the designated smoke coverage for the DEFAULT (ShengBTE)
+adaptive-broadening kernel (see issue #290): that kernel builds per-pair
+sigma from velocity differences, which are not invariant under the
+eigenvector gauge freedom in degenerate subspaces, so its conductivities
+are deterministic per machine but drift by up to a few percent across
+BLAS/LAPACK backends. Tolerances here are therefore deliberately loose
+sanity bands. Tight regression pinning lives in the per-format test files,
+which use gauge-invariant configurations (broadening_kernel='tdep' or
+fixed bandwidths).
 """
 
 # Import package, test suite, and other packages as needed
@@ -27,7 +37,7 @@ def phonons():
 
 def test_phase_space(phonons):
     phase_space = phonons.phase_space.sum()
-    np.testing.assert_approx_equal(phase_space, 113, significant=3)
+    np.testing.assert_allclose(phase_space, 113.0, rtol=1e-2, atol=0.0)
 
 
 
@@ -39,24 +49,24 @@ def test_sc_conductivity(phonons):
             .diagonal()
         )
     )
-    np.testing.assert_approx_equal(cond, 255, significant=3)
+    np.testing.assert_allclose(cond, 255.0, rtol=1e-2, atol=0.0)
 
 
 def test_qhgk_conductivity(phonons):
     cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 230, significant=3)
+    np.testing.assert_allclose(cond, 230.0, rtol=1e-2, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 226, significant=3)
+    np.testing.assert_allclose(cond, 226.0, rtol=1e-2, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 256, significant=3)
+    np.testing.assert_allclose(cond, 256.0, rtol=1e-2, atol=0.0)

--- a/kaldo/tests/test_crystal_d3q.py
+++ b/kaldo/tests/test_crystal_d3q.py
@@ -24,6 +24,7 @@ def phonons():
         # kpts=[14, 14, 14], # real-world case, test againest as example, and compare value with literature
         is_classic=False,
         temperature=300,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
     return phonons
@@ -46,20 +47,21 @@ def test_lagacy_format():
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 21, significant=2)
+    np.testing.assert_allclose(cond, 0.618239, rtol=5e-3, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 20, significant=2)
+    np.testing.assert_allclose(cond, 10.197727, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 22, significant=2)
+    np.testing.assert_allclose(cond, 10.173112, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_finite_size_np.py
+++ b/kaldo/tests/test_crystal_finite_size_np.py
@@ -22,6 +22,7 @@ def phonons():
         kpts=[5, 5, 5],
         is_classic=False,
         temperature=300,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
 
@@ -39,7 +40,7 @@ def test_sc_finite_size_conductivity_ms(phonons):
             finite_length_method="ms",
         ).conductivity.sum(axis=0)[0, 0]
     )
-    np.testing.assert_approx_equal(cond_ms, 185.96, significant=3)
+    np.testing.assert_allclose(cond_ms, 210.577436, rtol=5e-3, atol=0.0)
 
 
 def test_rta_finite_size_conductivity_ms(phonons):
@@ -48,7 +49,7 @@ def test_rta_finite_size_conductivity_ms(phonons):
             phonons=phonons, method="rta", storage="memory", length=(1e4, 0, 0), finite_length_method="ms"
         ).conductivity.sum(axis=0)[0, 0]
     )
-    np.testing.assert_approx_equal(cond_ms, 162.397, significant=3)
+    np.testing.assert_allclose(cond_ms, 167.271969, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_finite_size_conductivity_ms(phonons):
@@ -57,4 +58,4 @@ def test_inverse_finite_size_conductivity_ms(phonons):
             phonons=phonons, method="inverse", storage="memory", length=(1e4, 0, 0), finite_length_method="ms"
         ).conductivity.sum(axis=0)[0, 0]
     )
-    np.testing.assert_approx_equal(cond_ms, 180.718, significant=3)
+    np.testing.assert_allclose(cond_ms, 198.764287, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_is_unfolding.py
+++ b/kaldo/tests/test_crystal_is_unfolding.py
@@ -20,19 +20,21 @@ def phonons():
         is_classic=False,
         temperature=300,
         is_unfolding=True,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
     return phonons
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 141.26, significant=3)
+    np.testing.assert_allclose(cond, 2.270817, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 156.43, significant=3)
+    np.testing.assert_allclose(cond, 307.106420, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_isotopic.py
+++ b/kaldo/tests/test_crystal_isotopic.py
@@ -20,19 +20,21 @@ def phonons():
         is_classic=False,
         temperature=300,
         include_isotopes=True,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
     return phonons
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 187.5, significant=4)
+    np.testing.assert_allclose(cond, 2.993298, rtol=5e-3, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 183.3, significant=4)
+    np.testing.assert_allclose(cond, 183.721450, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_qe_vasp.py
+++ b/kaldo/tests/test_crystal_qe_vasp.py
@@ -80,7 +80,7 @@ def test_qhgk_conductivity(phonons):
     cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
                         diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 2.2, significant=2)
+    np.testing.assert_allclose(cond, 2.241208, rtol=5e-3, atol=0.0)
 
 
 def test_rta_conductivity(phonons):

--- a/kaldo/tests/test_crystal_qe_vasp.py
+++ b/kaldo/tests/test_crystal_qe_vasp.py
@@ -23,6 +23,7 @@ def phonons():
         kpts=[3, 3, 3],
         is_classic=False,
         temperature=300,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
     return phonons
@@ -88,7 +89,7 @@ def test_rta_conductivity(phonons):
     )
     # recalibrated after the ShengBTE FC3 parser fix (mod-wrapped cell offsets); the old value baked in
     # silently dropped force constants
-    np.testing.assert_approx_equal(cond, 2.8, significant=2)
+    np.testing.assert_allclose(cond, 4.500018, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
@@ -97,4 +98,4 @@ def test_inverse_conductivity(phonons):
     )
     # recalibrated after the ShengBTE FC3 parser fix (mod-wrapped cell offsets); the old value baked in
     # silently dropped force constants
-    np.testing.assert_approx_equal(cond, 2.5, significant=2)
+    np.testing.assert_allclose(cond, 5.049113, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_vasp.py
+++ b/kaldo/tests/test_crystal_vasp.py
@@ -23,6 +23,7 @@ def phonons():
         kpts=[3, 3, 3],
         is_classic=False,
         temperature=300,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
         storage="memory",
     )
     return phonons
@@ -45,20 +46,21 @@ def test_lagacy_format():
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_approx_equal(cond, 20, significant=2)
+    np.testing.assert_allclose(cond, 1.693686, rtol=5e-3, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 19, significant=2)
+    np.testing.assert_allclose(cond, 16.406325, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 18, significant=2)
+    np.testing.assert_allclose(cond, 16.576349, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_crystal_vasp_d3q.py
+++ b/kaldo/tests/test_crystal_vasp_d3q.py
@@ -59,14 +59,22 @@ def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_allclose(cond, 0.668516, rtol=5e-3, atol=0.0)
+    # Residual gauge sensitivity (issue #290): even with fixed sigma, per-mode
+    # |Phi3|^2 and velocities remain gauge-covariant within degenerate clusters,
+    # and on this strongly degenerate, low-kappa fixture the mode-summed BTE
+    # value still spreads ~2% across backends (arm64 0.6685, x86-64 0.6547).
+    # Band centered between the measured backends; only deterministic gauge
+    # canonicalization can tighten this further.
+    np.testing.assert_allclose(cond, 0.6616, rtol=3e-2, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_allclose(cond, 0.737106, rtol=5e-3, atol=0.0)
+    # See the residual-gauge note on test_rta_conductivity (#290):
+    # arm64 0.7371, x86-64 0.7194, band centered between them.
+    np.testing.assert_allclose(cond, 0.7283, rtol=3e-2, atol=0.0)
 
 
 def test_qhgk_conductivity_default_kernel_smoke():

--- a/kaldo/tests/test_crystal_vasp_d3q.py
+++ b/kaldo/tests/test_crystal_vasp_d3q.py
@@ -9,6 +9,12 @@ from kaldo.phonons import Phonons
 from kaldo.conductivity import Conductivity
 import pytest
 
+# Gauge-invariant regression configuration (issue #290): a fixed
+# third_bandwidth (and, for QHGK, a fixed diffusivity_bandwidth) removes the
+# eigenvector-gauge sensitivity of the default adaptive broadening, so these
+# goldens are machine-independent and pinned tightly. Default-kernel smoke
+# coverage lives in test_crystal.py (and one Ge smoke below, where present).
+
 
 @pytest.fixture(scope="session")
 def phonons():
@@ -23,6 +29,7 @@ def phonons():
         kpts=[3, 3, 3],
         is_classic=False,
         temperature=300,
+        third_bandwidth=0.5,
         storage="memory",
     )
     return phonons
@@ -42,20 +49,48 @@ def phonons():
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_allclose(cond, 0.825, rtol=3e-2, atol=0.0)
+    np.testing.assert_allclose(cond, 0.768016, rtol=5e-3, atol=0.0)
 
 
 def test_rta_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_allclose(cond, 0.688, rtol=3e-2, atol=0.0)
+    np.testing.assert_allclose(cond, 0.668516, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_allclose(cond, 0.738, rtol=3e-2, atol=0.0)
+    np.testing.assert_allclose(cond, 0.737106, rtol=5e-3, atol=0.0)
+
+
+def test_qhgk_conductivity_default_kernel_smoke():
+    """Smoke coverage of the DEFAULT adaptive-broadening path on Ge (#290).
+
+    The default ShengBTE kernel is eigenvector-gauge sensitive in degenerate
+    subspaces, so its value is deterministic per machine but spreads ~3%
+    across BLAS backends (measured arm64/Accelerate 0.837 vs x86-64/OpenBLAS
+    0.813). The band is centered between the observed backends and is
+    deliberately wide: this test exercises the default path, it does not pin
+    physics. Tight pinning lives in the fixed-bandwidth tests above.
+    """
+    forceconstants = ForceConstants.from_folder(
+        folder="kaldo/tests/ge-crystal/vasp-d3q",
+        supercell=[5, 5, 5],
+        third_supercell=[3, 3, 3],
+        format="vasp-d3q")
+    phonons = Phonons(
+        forceconstants=forceconstants,
+        kpts=[3, 3, 3],
+        is_classic=False,
+        temperature=300,
+        storage="memory",
+    )
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = np.abs(np.mean(cond.diagonal()))
+    np.testing.assert_allclose(cond, 0.825, rtol=3e-2, atol=0.0)

--- a/kaldo/tests/test_io.py
+++ b/kaldo/tests/test_io.py
@@ -22,6 +22,7 @@ def phonons():
         "temperature": 300,  # 'temperature'=300K
         "folder": "ALD_si_bulk",
         "storage": "formatted",
+        "third_bandwidth": 0.5,  # fixed: gauge-invariant regression config (#290)
     }
 
     phonons = Phonons(forceconstants=forceconstants, **phonons_config)
@@ -34,13 +35,14 @@ def phonons():
 
 
 def test_qhgk_conductivity(phonons):
-    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
+    cond = Conductivity(phonons=phonons, method="qhgk", storage="memory",
+                        diffusivity_bandwidth=1.0).conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
-    np.testing.assert_allclose(cond, 141.0, rtol=2e-2, atol=0.0)
+    np.testing.assert_allclose(cond, 2.251450, rtol=5e-3, atol=0.0)
 
 
 def test_inverse_conductivity(phonons):
     cond = np.abs(
         np.mean(Conductivity(phonons=phonons, method="inverse", storage="memory").conductivity.sum(axis=0).diagonal())
     )
-    np.testing.assert_approx_equal(cond, 154, significant=3)
+    np.testing.assert_allclose(cond, 300.205922, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_tdep.py
+++ b/kaldo/tests/test_tdep.py
@@ -20,6 +20,7 @@ def phonons():
         folder=".",
         storage="memory",
         is_unfolding=False,
+        third_bandwidth=0.5,  # fixed: gauge-invariant regression config (#290)
     )
     return phonons
 
@@ -27,5 +28,5 @@ def phonons():
 def test_tdep_conductivity_300(phonons):
     phonons.temperature = 300
     cond = Conductivity(phonons=phonons, method="rta", storage="memory").conductivity.sum(axis=0).diagonal().mean()
-    expected_cond = 72.0
-    np.testing.assert_approx_equal(cond, expected_cond, significant=2)
+    expected_cond = 68.753938
+    np.testing.assert_allclose(cond, expected_cond, rtol=5e-3, atol=0.0)


### PR DESCRIPTION
## Context

First deliverable of #290. The default adaptive broadening builds per-pair sigma from velocity differences, which are not invariant under the eigenvector gauge freedom in degenerate subspaces. Conductivities computed with it are deterministic per machine but spread by up to ~3% across BLAS backends (measured arm64/Accelerate vs x86-64/OpenBLAS; the Ge 3x3x3 mesh has 25% of its modes in exactly degenerate pairs). Four goldens had already been widened or spot-fixed one at a time to absorb this (#260, #281, #284); roughly ten more test files pinned default-kernel conductivities at 2-4 significant figures and were one BLAS upgrade away from flaking. Wide bands also mean the tests cannot detect real sub-3% regressions.

## What changed

**Tight, gauge-invariant pins.** The per-format transport regression tests now use a fixed `third_bandwidth=0.5` THz for the BTE solvers, plus a fixed `diffusivity_bandwidth=1.0` for QHGK (the #260 pattern; the QHGK value is then independent of the anharmonic bandwidths, verified identical across broadening configurations). Goldens are recomputed under these configurations and pinned at rtol=5e-3, several times tighter than the bands they replace. @AlessandroSerra's cross-backend measurements in #270 calibrate the tolerance: 0.12% spread for the fixed-bandwidth configuration vs 0.9% for the default. Converted: crystal_vasp_d3q, crystal_d3q, crystal_vasp, crystal_qe_vasp (rta/inverse), io, crystal_is_unfolding, crystal_isotopic, crystal_finite_size_np, tdep.

**Why not the tdep kernel for the pins:** it is equally gauge-invariant, but on these coarse 27-point test meshes its sigma saturates the energy-conservation delta (several THz wide), which would make the pins insensitive to real broadening regressions. It keeps dedicated coverage in test_broadening_tdep.py, and test_broadening_shapes_crystal now uses it with degenerate-triplet-mean assertions (the old single-mode pin lived inside the Gamma optical triplet, doubly gauge-sensitive).

**Default-kernel smoke preserved deliberately:** test_crystal.py (all four solvers on Si, documented 1e-2 bands) and one Ge qhgk smoke in test_crystal_vasp_d3q.py with the cross-backend-centered 3e-2 band. These exercise the default adaptive path without pretending to pin physics.

**The new goldens are new reference values on a different broadening recipe**, deliberately not comparable to the old numbers (e.g. the Si inverse reference moves from 154 to 300.2 because the fixed 0.5 THz sigma is narrower than the adaptive median ~1.3 THz).

## Cross-backend validation

All 34 converted tests pass on arm64/Accelerate at the pinned values. This CI run on x86-64/OpenBLAS is the second backend: any pin it fails measures a residual spread above 5e-3 and will be adjusted from that data.

Part of #290; the physics-side follow-up there (deterministic gauge canonicalization in degenerate clusters) would eventually let even per-mode observables pin tightly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated phonon conductivity and broadening regression coverage to use fixed, reproducible configurations (including `third_bandwidth` and `tdep`-kernel setup).
  - Recalibrated expected conductivity and bandwidth benchmark values across crystal, finite-size, isotope, QE/VASP, and TDEP scenarios.
  - Switched from significant-digit comparisons to `assert_allclose` with explicit tolerances to improve numerical robustness across BLAS backends.
  - Added a smoke test covering the default adaptive broadening kernel path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->