### PR TITLE
Warn when the QE force-constant file carries no NAC data

### DIFF
--- a/kaldo/interfaces/shengbte_io.py
+++ b/kaldo/interfaces/shengbte_io.py
@@ -123,6 +123,11 @@ def read_second_order_qe_matrix(filename):
                     charges[na + 1, alpha, :] = file.readline().split()
         else:
             charges = None
+            logging.warning(
+                'No Born effective charges / dielectric tensor in %s (NAC flag F): '
+                'the non-analytic correction is disabled. For a polar material the '
+                'dispersion will lack LO-TO splitting; re-run q2r.x with zeu=.true. '
+                'and epsil=.true. if NAC is needed.', filename)
 
         # Read second order force constants
         # read t1*t2*t3 supercell


### PR DESCRIPTION
read_second_order_qe_matrix silently set charges=None when the espresso.ifc2 NAC flag is F, so a polar material quietly loses its LO-TO splitting and the dispersion looks plausible but is wrong (item 4 of #279). The reader now warns, naming the file and the q2r.x flags (zeu=.true., epsil=.true.) that produce the NAC block. Flag-T files are unchanged; the si/ge/gan QE suites pass unchanged.

The other half of item 4 (the legacy nac_dynmat hexagonal phase error) belongs to #262.