### PR TITLE
Deterministic eigenvector gauge in degenerate subspaces (spike, #290)

### DIFF
--- a/kaldo/gauge.py
+++ b/kaldo/gauge.py
@@ -1,0 +1,75 @@
+"""Deterministic eigenvector gauge for degenerate subspaces.
+
+Numerical diagonalizers return an arbitrary orthonormal basis within each
+degenerate eigenvalue cluster, and the choice differs across BLAS/LAPACK
+backends. Every observable built from mode-resolved eigenvector quantities
+inside those clusters (velocities, scattering amplitudes, per-mode
+bandwidths) inherits that arbitrariness, which is the root cause tracked in
+issue #290.
+
+This module removes the freedom: within each degenerate cluster the basis is
+rotated to diagonalize a fixed generic Hermitian operator (a graded diagonal
+in the Cartesian-atom representation), whose projected spectrum is
+non-degenerate for every cluster met in practice, and each vector's phase is
+fixed by making its largest-magnitude component real and positive. The result
+depends only on the dynamical matrix, not on the diagonalizer, so two
+machines produce identical eigenvectors.
+"""
+import numpy as np
+
+
+def canonicalize_eigenvectors(eigenvalues, eigenvectors, degeneracy_tol=1e-6):
+    """Rotate degenerate clusters into a machine-independent canonical basis.
+
+    Parameters
+    ----------
+    eigenvalues : ndarray, shape (n,)
+        Eigenvalues in ascending order (as returned by ``eigh``).
+    eigenvectors : ndarray, shape (n, n)
+        Eigenvectors as columns, ``eigenvectors[:, i]`` belonging to
+        ``eigenvalues[i]``. Real or complex.
+    degeneracy_tol : float
+        Two adjacent eigenvalues closer than ``degeneracy_tol`` (relative to
+        the spectrum's scale, with an absolute floor) belong to one cluster.
+
+    Returns
+    -------
+    ndarray
+        Eigenvectors with every degenerate cluster rotated to the canonical
+        basis and every column's phase fixed. Non-degenerate columns only get
+        the phase fix.
+    """
+    n = len(eigenvalues)
+    out = np.array(eigenvectors, copy=True)
+    scale = max(np.max(np.abs(eigenvalues)), 1.0)
+    tol = degeneracy_tol * scale
+
+    # The gauge-fixing operator: a graded diagonal. Its projection onto any
+    # cluster subspace is generically non-degenerate, and it is the same on
+    # every machine.
+    grading = np.arange(n, dtype=np.float64)
+
+    start = 0
+    while start < n:
+        end = start + 1
+        while end < n and abs(eigenvalues[end] - eigenvalues[end - 1]) < tol:
+            end += 1
+        if end - start > 1:
+            block = out[:, start:end]
+            # Project the grading operator into the cluster and diagonalize:
+            # projected[i, j] = <v_i| G |v_j> with G diagonal.
+            projected = block.conj().T @ (grading[:, np.newaxis] * block)
+            projected = 0.5 * (projected + projected.conj().T)
+            _, rotation = np.linalg.eigh(projected)
+            out[:, start:end] = block @ rotation
+        start = end
+
+    # Phase fix per column: largest-|component| entry real and positive.
+    # Ties on magnitude are broken by the lowest index (deterministic).
+    for i in range(n):
+        column = out[:, i]
+        j = int(np.argmax(np.abs(column)))
+        pivot = column[j]
+        if np.abs(pivot) > 0:
+            out[:, i] = column * (np.abs(pivot) / pivot)
+    return out

--- a/kaldo/observables/harmonic_with_q.py
+++ b/kaldo/observables/harmonic_with_q.py
@@ -65,9 +65,15 @@ class HarmonicWithQ(Observable, Storable):
                  is_nw=False,
                  is_unfolding=False,
                  is_amorphous=False,
+                 is_canonical_gauge=False,
                  *kargs,
                  **kwargs):
         super().__init__(*kargs, **kwargs)
+        if is_canonical_gauge and is_unfolding:
+            raise NotImplementedError(
+                'is_canonical_gauge is not wired into the unfolded eigensystem path yet (#290).'
+            )
+        self.is_canonical_gauge = is_canonical_gauge
         # Input arguments
         self.q_point = q_point
         self.atoms = second.atoms
@@ -118,6 +124,14 @@ class HarmonicWithQ(Observable, Storable):
         else:
             # Use default implementation for other properties
             super()._save_formatted_property(property_name, name, data)
+
+    def _get_folder_path_components(self, label):
+        components = []
+        # A canonical-gauge run must never share stored eigensystems (or
+        # anything derived from them) with a default-gauge run.
+        if self.is_canonical_gauge:
+            components.append('canonical_gauge')
+        return components
 
     @lazy_property(label='<q_point>')
     def frequency(self):
@@ -360,7 +374,14 @@ class HarmonicWithQ(Observable, Storable):
         else:
             log_size(self._dynmat_fourier.shape, type=complex, name='eigensystem')
             esystem = tf.linalg.eigh(dyn_s)
-            esystem = tf.concat(axis=0, values=(esystem[0][tf.newaxis, :], esystem[1]))
+            eigenvalues, eigenvectors = esystem[0], esystem[1]
+            if self.is_canonical_gauge:
+                from kaldo.gauge import canonicalize_eigenvectors
+                eigenvectors = tf.convert_to_tensor(
+                    canonicalize_eigenvectors(eigenvalues.numpy(), eigenvectors.numpy()),
+                    dtype=eigenvectors.dtype,
+                )
+            esystem = tf.concat(axis=0, values=(eigenvalues[tf.newaxis, :], eigenvectors))
         return esystem
 
     def calculate_participation_ratio(self):

--- a/kaldo/phonons.py
+++ b/kaldo/phonons.py
@@ -427,6 +427,14 @@ class Phonons(Storable):
         Enforce detailed balance when calculating anharmonic properties. Useful for
         simulations where it may be difficult to get a sufficiently dense k-point grid.
         Default: False
+    is_canonical_gauge : bool
+        Experimental (#290). Rotate every degenerate eigenvector cluster into
+        a deterministic canonical basis (see ``kaldo.gauge``), making
+        mode-resolved observables machine-independent across BLAS/LAPACK
+        backends. Changes per-mode values relative to the default arbitrary
+        gauge; gauge-invariant quantities are unaffected. Not implemented for
+        ``is_unfolding=True``.
+        Default: ``False``
     is_unfolding : bool
         If the second order force constants need to be unfolded like in P. B. Allen
         et al., Phys. Rev. B 87, 085322 (2013) set this to True.
@@ -516,6 +524,7 @@ class Phonons(Storable):
                  grid_type: str = "C",
                  is_balanced: bool = False,
                  is_unfolding: bool = False,
+                 is_canonical_gauge: bool = False,
                  g_factor: ArrayLike = None,
                  is_symmetrizing_frequency: bool = False, 
                  is_antisymmetrizing_velocity: bool = False,
@@ -539,6 +548,7 @@ class Phonons(Storable):
         self._grid_type = grid_type
         self._reciprocal_grid = Grid(self.kpts, order=self._grid_type)
         self.is_unfolding = is_unfolding
+        self.is_canonical_gauge = is_canonical_gauge
         if self.is_unfolding:
             logging.info('Using unfolding.')
         self.min_frequency = min_frequency
@@ -677,6 +687,7 @@ class Phonons(Storable):
                                    storage=self.storage,
                                    is_nw=self.is_nw,
                                    is_unfolding=self.is_unfolding,
+                                   is_canonical_gauge=self.is_canonical_gauge,
                                    is_amorphous=self._is_amorphous)
 
             physical_mode[ik] = phonon.physical_mode
@@ -708,6 +719,7 @@ class Phonons(Storable):
                                    storage=self.storage,
                                    is_nw=self.is_nw,
                                    is_unfolding=self.is_unfolding,
+                                   is_canonical_gauge=self.is_canonical_gauge,
                                    is_amorphous=self._is_amorphous)
             frequency[ik] = phonon.frequency
 
@@ -737,6 +749,7 @@ class Phonons(Storable):
                                    storage=self.storage,
                                    is_nw=self.is_nw,
                                    is_unfolding=self.is_unfolding,
+                                   is_canonical_gauge=self.is_canonical_gauge,
                                    is_amorphous=self._is_amorphous)
 
             participation_ratio[ik] = phonon.participation_ratio
@@ -767,6 +780,7 @@ class Phonons(Storable):
                                    storage=self.storage,
                                    is_nw=self.is_nw,
                                    is_unfolding=self.is_unfolding,
+                                   is_canonical_gauge=self.is_canonical_gauge,
                                    is_amorphous=self._is_amorphous)
             velocity[ik] = phonon.velocity
 
@@ -800,6 +814,7 @@ class Phonons(Storable):
                                    storage=self.storage,
                                    is_nw=self.is_nw,
                                    is_unfolding=self.is_unfolding,
+                                   is_canonical_gauge=self.is_canonical_gauge,
                                    is_amorphous=self._is_amorphous)
 
             eigensystem[ik] = phonon._eigensystem
@@ -834,6 +849,7 @@ class Phonons(Storable):
                                        is_classic=self.is_classic,
                                        is_nw=self.is_nw,
                                        is_unfolding=self.is_unfolding,
+                                       is_canonical_gauge=self.is_canonical_gauge,
                                        is_amorphous=self._is_amorphous)
             c_v[ik] = phonon.heat_capacity
         return c_v
@@ -865,6 +881,7 @@ class Phonons(Storable):
                                        is_classic=self.is_classic,
                                        is_nw=self.is_nw,
                                        is_unfolding=self.is_unfolding,
+                                       is_canonical_gauge=self.is_canonical_gauge,
                                        is_amorphous=self._is_amorphous)
 
             heat_capacity_2d[ik] = phonon.heat_capacity_2d
@@ -900,6 +917,7 @@ class Phonons(Storable):
                                        is_classic=self.is_classic,
                                        is_nw=self.is_nw,
                                        is_unfolding=self.is_unfolding,
+                                       is_canonical_gauge=self.is_canonical_gauge,
                                        is_amorphous=self._is_amorphous)
 
             population[ik] = phonon.population

--- a/kaldo/tests/test_crystal_vasp_d3q.py
+++ b/kaldo/tests/test_crystal_vasp_d3q.py
@@ -102,3 +102,42 @@ def test_qhgk_conductivity_default_kernel_smoke():
     cond = Conductivity(phonons=phonons, method="qhgk", storage="memory").conductivity.sum(axis=0)
     cond = np.abs(np.mean(cond.diagonal()))
     np.testing.assert_allclose(cond, 0.825, rtol=3e-2, atol=0.0)
+
+
+@pytest.fixture(scope="session")
+def canonical_phonons():
+    forceconstants = ForceConstants.from_folder(
+        folder="kaldo/tests/ge-crystal/vasp-d3q",
+        supercell=[5, 5, 5],
+        third_supercell=[3, 3, 3],
+        format="vasp-d3q")
+    return Phonons(
+        forceconstants=forceconstants,
+        kpts=[3, 3, 3],
+        is_classic=False,
+        temperature=300,
+        third_bandwidth=0.5,
+        is_canonical_gauge=True,
+        storage="memory",
+    )
+
+
+def test_rta_conductivity_canonical_gauge(canonical_phonons):
+    """The #290 benchmark: with the deterministic eigenvector gauge the
+    per-mode gauge covariance that kept a ~2% cross-backend residual on this
+    fixture is removed, so the pin holds at the tight tolerance the default
+    gauge could not."""
+    cond = np.abs(
+        np.mean(Conductivity(phonons=canonical_phonons, method="rta",
+                             storage="memory").conductivity.sum(axis=0).diagonal())
+    )
+    np.testing.assert_allclose(cond, 0.647088, rtol=5e-3, atol=0.0)
+
+
+def test_inverse_conductivity_canonical_gauge(canonical_phonons):
+    """See test_rta_conductivity_canonical_gauge."""
+    cond = np.abs(
+        np.mean(Conductivity(phonons=canonical_phonons, method="inverse",
+                             storage="memory").conductivity.sum(axis=0).diagonal())
+    )
+    np.testing.assert_allclose(cond, 0.714601, rtol=5e-3, atol=0.0)

--- a/kaldo/tests/test_gauge.py
+++ b/kaldo/tests/test_gauge.py
@@ -1,0 +1,66 @@
+"""
+Tests for the deterministic eigenvector gauge (issue #290).
+
+The referee is local gauge scrambling: applying a random unitary rotation
+within each degenerate cluster simulates exactly the freedom a different
+BLAS backend exercises. Canonicalization must erase it.
+"""
+import numpy as np
+
+from kaldo.gauge import canonicalize_eigenvectors
+
+
+def _random_hermitian_with_degeneracies(n, rng, complex_valued=True):
+    """Hermitian matrix with an exactly threefold and an exactly twofold
+    degenerate eigenvalue, plus non-degenerate rest."""
+    eigenvalues = np.sort(rng.standard_normal(n) * 10)
+    eigenvalues[1:4] = eigenvalues[1]      # triplet
+    eigenvalues[6:8] = eigenvalues[6]      # doublet
+    if complex_valued:
+        m = rng.standard_normal((n, n)) + 1j * rng.standard_normal((n, n))
+    else:
+        m = rng.standard_normal((n, n))
+    q, _ = np.linalg.qr(m)
+    return (q * eigenvalues) @ q.conj().T, eigenvalues
+
+
+def _scramble_clusters(eigenvalues, eigenvectors, rng, tol=1e-6):
+    """Apply a random unitary within each degenerate cluster and random
+    phases everywhere: the gauge freedom a different backend exercises."""
+    out = np.array(eigenvectors, copy=True)
+    n = len(eigenvalues)
+    start = 0
+    while start < n:
+        end = start + 1
+        while end < n and abs(eigenvalues[end] - eigenvalues[end - 1]) < tol:
+            end += 1
+        size = end - start
+        if size > 1:
+            m = rng.standard_normal((size, size)) + 1j * rng.standard_normal((size, size))
+            u, _ = np.linalg.qr(m)
+            out[:, start:end] = out[:, start:end] @ u
+        start = end
+    phases = np.exp(2j * np.pi * rng.random(n))
+    return out * phases[np.newaxis, :]
+
+
+def test_canonical_gauge_erases_cluster_scrambling():
+    rng = np.random.default_rng(0)
+    h, eigenvalues = _random_hermitian_with_degeneracies(12, rng)
+    w, v = np.linalg.eigh(h)
+
+    reference = canonicalize_eigenvectors(w, v)
+    scrambled = _scramble_clusters(w, v, rng)
+    recovered = canonicalize_eigenvectors(w, scrambled)
+
+    np.testing.assert_allclose(recovered, reference, rtol=0.0, atol=1e-10)
+
+
+def test_canonical_gauge_preserves_the_eigensystem():
+    rng = np.random.default_rng(7)
+    h, _ = _random_hermitian_with_degeneracies(12, rng)
+    w, v = np.linalg.eigh(h)
+    canonical = canonicalize_eigenvectors(w, v)
+    # Still an orthonormal eigenbasis of h with the same eigenvalues
+    np.testing.assert_allclose(canonical.conj().T @ canonical, np.eye(12), atol=1e-12)
+    np.testing.assert_allclose(h @ canonical, canonical * w[np.newaxis, :], atol=1e-9)


### PR DESCRIPTION
Step 2 of #290, the root-cause fix. Diagonalizers return an arbitrary basis inside each degenerate cluster, and different BLAS backends pick differently, so every mode-resolved quantity inherits the choice. kaldo.gauge.canonicalize_eigenvectors removes the freedom: each cluster is rotated into the eigenbasis of a fixed operator (a graded diagonal projected into the cluster) and each phase is pinned on the largest component. The result depends only on the dynamical matrix, so two machines produce the same eigenvectors.

Opt-in via Phonons(is_canonical_gauge=True); defaults are untouched. All existing goldens pass, and the gauge-free QHGK fixed-bandwidth value is bit-identical under the flag. The unfolded path raises NotImplementedError for now, and canonical runs store under a separate cache path.

Two referees. The unit test scrambles the gauge with random unitaries inside each cluster plus random phases (the freedom another backend exercises) and asserts canonicalization recovers the reference basis to 1e-10. The cross-backend one: the Ge vasp-d3q rta and inverse values, which keep a ~2% backend spread even with fixed sigma, are pinned under the canonical gauge at rtol=5e-3 from arm64 numbers (0.647088 and 0.714601), and the x86 CI run holds them. That was the success criterion #290 set for this spike.

Making this the default would change published per-mode numbers, so that stays a separate discussion. Once merged, the two 3e-2 bands in test_crystal_vasp_d3q can be tightened.