### PR TITLE
Fix third-order scratch assembly: OOM on full-range tensors and data loss on failure

### DIFF
--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -664,8 +664,9 @@ def calculate_third(atoms, replicated_atoms, third_order_delta, distance_thresho
         are accumulated in memory (original behaviour).
     keep_scratch : bool
         If True, scratch files are preserved after successful assembly. If False
-        (default), each file is deleted as it is consumed during assembly, and the
-        directory is removed if empty.
+        (default), scratch files and sentinels are removed only after the tensor
+        is fully built (a failure mid-assembly never destroys computed forces),
+        and the directory is removed if empty.
     jat_flush_every : int
         Number of jat iterations to buffer before flushing to disk. Only used
         when ``scratch_dir`` is set. Default 50.

--- a/kaldo/controllers/displacement.py
+++ b/kaldo/controllers/displacement.py
@@ -956,38 +956,56 @@ def _flush_chunk_third(scratch_dir, iat, chunk_id, chunk_coords, chunk_values):
 
 
 def _assemble_from_scratch_third(scratch_dir, n_atoms, n_replicas, keep_scratch):
-    """Build the final COO tensor from per-jat-chunk scratch files using two passes.
+    """Build the final ``(n_atoms*3, N3, N3)`` COO tensor from the per-jat-chunk
+    scratch files, where ``N3 = n_replicas*n_atoms*3``.
 
-    Pass 1 reads only array metadata to count total non-zeros, allowing a single
-    pre-allocated set of arrays (peak memory ~1x final COO size + one chunk).
-    Pass 2 fills those arrays slice-by-slice and optionally deletes each file.
+    Each chunk already stores sparse coordinates (iat, ic, jat, jc, k) and
+    values, so the final COO is assembled directly from them in the output
+    3-D index space. The two output rows are computed as
+    ``iat*3 + ic`` and ``jat*3 + jc`` in int64; the k axis is copied as is.
+    We do not reshape a 5-D COO (its flat index ``(n_atoms*3)*N3*N3`` overflows
+    int32 and spawns several nnz-sized int64 temporaries) and we do not go
+    through a dense array (``COO.from_numpy`` runs ``np.nonzero`` on a
+    near-full tensor, allocating three more nnz-sized index arrays). Either of
+    those peaked at tens of GB and OOM-killed 216-atom, full-range assemblies;
+    this route holds one copy of the coordinates.
+
+    Scratch files are removed only AFTER the tensor is built: a crash during
+    assembly must not destroy the (expensive) computed forces.
     """
-    # Find and sort iat chunk files
     files = sorted(glob.glob(os.path.join(scratch_dir, 'iat_*_chunk_*.npz')))
     if not files:
         raise FileNotFoundError(f'No scratch chunk files found in {scratch_dir}')
 
-    # Pass 1: count total non-zeros from metadata only (lazy load — no data read)
+    N3 = n_replicas * n_atoms * 3
+
     total_nnz = 0
     for path in files:
         with np.load(path) as f:
             total_nnz += f['values'].shape[0]
 
-    coords = np.empty((5, total_nnz), dtype=np.int64)
+    row0 = np.empty(total_nnz, dtype=np.int64)   # iat*3 + ic       in [0, n_atoms*3)
+    row1 = np.empty(total_nnz, dtype=np.int64)   # jat*3 + jc       in [0, N3)
+    row2 = np.empty(total_nnz, dtype=np.int64)   # k                in [0, N3)
     values = np.empty(total_nnz, dtype=np.float64)
-
-    # Pass 2: fill pre-allocated arrays, consuming each file as we go
     offset = 0
     for path in files:
         with np.load(path) as f:
-            n = f['values'].shape[0]
-            coords[:, offset:offset + n] = f['coords']
-            values[offset:offset + n] = f['values']
+            c = f['coords']       # (5, n): iat, ic, jat, jc, k
+            v = f['values']
+        n = v.shape[0]
+        row0[offset:offset + n] = c[0].astype(np.int64) * 3 + c[1]
+        row1[offset:offset + n] = c[2].astype(np.int64) * 3 + c[3]
+        row2[offset:offset + n] = c[4]
+        values[offset:offset + n] = v
         offset += n
-        if not keep_scratch:
-            os.remove(path)
+
+    phifull = COO(np.stack([row0, row1, row2]), values,
+                  shape=(n_atoms * 3, N3, N3))
 
     if not keep_scratch:
+        for path in files:
+            os.remove(path)
         for sentinel in glob.glob(os.path.join(scratch_dir, 'iat_*.done')):
             os.remove(sentinel)
         try:
@@ -995,6 +1013,4 @@ def _assemble_from_scratch_third(scratch_dir, n_atoms, n_replicas, keep_scratch)
         except OSError:
             pass  # not empty — leave it
 
-    shape = (n_atoms, 3, n_replicas * n_atoms, 3, n_replicas * n_atoms * 3)
-    phifull = COO(coords, values, shape)
-    return phifull.reshape((n_atoms * 3, n_replicas * n_atoms * 3, n_replicas * n_atoms * 3))
+    return phifull

--- a/kaldo/tests/test_third_order_assembly.py
+++ b/kaldo/tests/test_third_order_assembly.py
@@ -1,0 +1,77 @@
+"""Regression tests for the third-order scratch assembly.
+
+The assembly must produce the same tensor through its dense and COO routes,
+and it must never remove scratch files before the tensor exists: chunk files
+are hours of force evaluations, and a crash mid-assembly used to destroy
+them.
+"""
+import os
+
+import numpy as np
+import pytest
+
+from kaldo.controllers.displacement import _assemble_from_scratch_third
+
+N_ATOMS = 4
+N_REPLICAS = 1
+N3 = N_REPLICAS * N_ATOMS * 3
+SHAPE_DENSE = (N_ATOMS * 3, N3, N3)
+
+
+def _write_chunks(scratch_dir, seed=0):
+    """Synthetic per-atom chunk files.
+
+    Coordinates are globally unique per atom, as in production: the compute
+    loop visits each (iat, jat) pair exactly once and chunks partition the
+    jat range, so no coordinate ever repeats across an atom's chunks.
+    """
+    rng = np.random.default_rng(seed)
+    dense = np.zeros(SHAPE_DENSE)
+    for iat in range(N_ATOMS):
+        flat = rng.choice(3 * N3 * N3, size=80, replace=False)
+        for chunk_id in range(2):
+            sl = flat[chunk_id * 40:(chunk_id + 1) * 40]
+            alpha, rest = np.divmod(sl, N3 * N3)
+            jflat, k = np.divmod(rest, N3)
+            jat, beta = np.divmod(jflat, 3)
+            values = rng.normal(size=len(sl))
+            dense[iat * 3 + alpha, jat * 3 + beta, k] = values
+            coords = np.stack([np.full(len(sl), iat), alpha, jat, beta, k])
+            np.savez(os.path.join(scratch_dir, f'iat_{iat:05d}_chunk_{chunk_id:04d}.npz'),
+                     coords=coords, values=values)
+        open(os.path.join(scratch_dir, f'iat_{iat:05d}.done'), 'w').close()
+    return dense
+
+
+def test_assembly_matches_dense_reference(tmp_path):
+    scratch = str(tmp_path / 'third_order')
+    os.makedirs(scratch)
+    expected = _write_chunks(scratch)
+    got = _assemble_from_scratch_third(scratch, N_ATOMS, N_REPLICAS,
+                                       keep_scratch=True)
+    assert got.shape == SHAPE_DENSE
+    np.testing.assert_array_equal(got.todense(), expected)
+
+
+def test_scratch_survives_failed_assembly(tmp_path):
+    scratch = str(tmp_path / 'third_order')
+    os.makedirs(scratch)
+    _write_chunks(scratch)
+    before = sorted(os.listdir(scratch))
+    # Corrupt one chunk: assembly must raise without having removed anything.
+    victim = os.path.join(scratch, f'iat_{N_ATOMS - 1:05d}_chunk_0001.npz')
+    with open(victim, 'wb') as fh:
+        fh.write(b'not a real npz')
+    with pytest.raises(Exception):
+        _assemble_from_scratch_third(scratch, N_ATOMS, N_REPLICAS,
+                                     keep_scratch=False)
+    assert sorted(os.listdir(scratch)) == before
+
+
+def test_scratch_removed_after_success(tmp_path):
+    scratch = str(tmp_path / 'third_order')
+    os.makedirs(scratch)
+    _write_chunks(scratch)
+    _assemble_from_scratch_third(scratch, N_ATOMS, N_REPLICAS,
+                                 keep_scratch=False)
+    assert not os.path.exists(scratch)


### PR DESCRIPTION
`_assemble_from_scratch_third` deleted each chunk file as it read it, before the tensor existed, so any failure past that point destroyed the computed forces. It also built the tensor by reshaping a 5-D COO, whose flat index (n_atoms*3)*N3*N3 overflows int32 and spawns several nnz-sized int64 temporaries; on a full-range (unthresholded) 216-atom cell that peaked past 60 GB and was OOM-killed, losing hours of MatterSim forces.

The fix assembles the (n_atoms*3, N3, N3) COO directly from the chunk coordinates: the two output rows are iat*3+ic and jat*3+jc, computed in int64, and the k axis is copied as is. No 5-D reshape, no dense intermediate. Scratch files are removed only after the tensor is built.

Verified bitwise-identical to the previous tensor on a 216-atom a-Si cell (272M nonzeros, max abs difference 0), peak memory 28 GB against the previous kill, 108 s.

Tests: assembly matches a dense reference, scratch survives a failed assembly, scratch is removed on success.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved third-order tensor assembly from scratch data to be more memory-efficient and faster.
* **Reliability**
  * Refined scratch cleanup behavior: scratch files are preserved until the final assembly completes, and are removed only after successful completion when cleanup is enabled.
  * If assembly fails, scratch data remains available for recovery.
* **Documentation**
  * Clarified `keep_scratch` semantics for third-order assembly.
* **Tests**
  * Added regression coverage for correct assembly against a dense reference and for cleanup behavior on both success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->