### PR TITLE
NAC bugs in `HarmonicWithQ`

### DIFF
--- a/kaldo/observables/harmonic_with_q.py
+++ b/kaldo/observables/harmonic_with_q.py
@@ -16,6 +16,16 @@ logging = get_logger()
 
 MIN_N_MODES_TO_STORE = 1000
 
+
+def _ewald_reciprocal_scale(cell):
+    """Reciprocal length |inv(cell)[0, 0]| that sets the Ewald Gaussian width of
+    the non-analytic correction. Shared by ``nac_dynmat`` (which normalises its
+    reciprocal grid by it, with Lambda = 1) and ``nac_derivatives`` (which sets
+    its Ewald parameter Lambda from it) so that the NAC group-velocity operator
+    stays the exact q-gradient of the NAC dynamical matrix. See the note in
+    ``nac_derivatives``."""
+    return np.abs(np.round(np.linalg.inv(cell), 12)[0, 0])
+
 _warned_incommensurate = False
 
 
@@ -528,7 +538,7 @@ class HarmonicWithQ(Observable, Storable):
         positions_n = atoms.positions.copy() / a_max  # Normalized positions
         distances_n = positions_n[:, None, :] - positions_n[None, :, :]  # distance in crystal coordinates
         reciprocal_n = np.round(np.linalg.inv(atoms.cell), 12)  # round to avoid accumulation of error
-        c_recip = np.abs(reciprocal_n[0, 0])  # length used to normalize reciprocal vectors
+        c_recip = _ewald_reciprocal_scale(atoms.cell)  # length used to normalize reciprocal vectors (shared with nac_derivatives)
         reciprocal_n /= c_recip  # Normalized reciprocal cell
         # Prefactor for the physical G.r phase (see phase factor below). g_positions and
         # distances_n are built in the normalized unit system only to set the Ewald grid and
@@ -650,7 +660,15 @@ class HarmonicWithQ(Observable, Storable):
         if gmax==None:
             gmax = 14  # maximum reciprocal vector (same default value in ShengBTE/QE)
         if Lambda==None:
-            Lambda = (2*np.pi*units.Bohr/np.linalg.norm(cell[0,:]))**2  # Ewald parameter
+            # Ewald parameter. Must reproduce the SAME physical Gaussian width as
+            # nac_dynmat, which normalises its reciprocal grid by
+            # c_recip = |inv(cell)[0, 0]| and uses Lambda = 1. Otherwise
+            # nac_derivatives is not the q-gradient of nac_dynmat and the NAC
+            # group velocities are wrong for cells whose first lattice vector is
+            # not axis-aligned (e.g. FCC primitive: ~8%). The historical form
+            # (2*np.pi*units.Bohr/np.linalg.norm(cell[0,:]))**2 coincides with
+            # this only when |cell[0,:]| * |inv(cell)[0, 0]| == 1.
+            Lambda = (2*np.pi*_ewald_reciprocal_scale(cell)*units.Bohr)**2  # Ewald parameter
         geg0 = 4 * Lambda * gmax
         omega_bohr = np.linalg.det(atoms.cell.array / units.Bohr) # Vol. in Bohr^3
         positions_bohr = atoms.positions.copy() / units.Bohr

--- a/kaldo/observables/harmonic_with_q.py
+++ b/kaldo/observables/harmonic_with_q.py
@@ -524,10 +524,20 @@ class HarmonicWithQ(Observable, Storable):
             Lambda = 1 # (2*np.pi*units.Bohr/np.linalg.norm(atoms.cell[0,:]))**2
         geg0 = 4 * Lambda * gmax
         omega_bohr = np.linalg.det(atoms.cell.array / units.Bohr) # Vol. in Bohr^3
-        positions_n = atoms.positions.copy() / atoms.cell[0, :].max()  # Normalized positions
+        a_max = atoms.cell[0, :].max()  # length used to normalize real-space distances
+        positions_n = atoms.positions.copy() / a_max  # Normalized positions
         distances_n = positions_n[:, None, :] - positions_n[None, :, :]  # distance in crystal coordinates
         reciprocal_n = np.round(np.linalg.inv(atoms.cell), 12)  # round to avoid accumulation of error
-        reciprocal_n /= np.abs(reciprocal_n[0, 0])  # Normalized reciprocal cell
+        c_recip = np.abs(reciprocal_n[0, 0])  # length used to normalize reciprocal vectors
+        reciprocal_n /= c_recip  # Normalized reciprocal cell
+        # Prefactor for the physical G.r phase (see phase factor below). g_positions and
+        # distances_n are built in the normalized unit system only to set the Ewald grid and
+        # cutoff; the phase itself must be evaluated in physical units, i.e. exp(i G.r) with G
+        # in 2*pi/Bohr and r in Bohr, exactly as in nac_derivatives. In the normalized
+        # variables that physical phase is 2*pi * a_max * c_recip * (g_positions . distances_n).
+        # The historical prefactor of pi is only correct for an FCC primitive cell, where
+        # c_recip * a_max == 0.5; for any other Bravais lattice it applies half the phase.
+        phase_prefactor = 2 * np.pi * a_max * c_recip
         correction_matrix = tf.zeros([3, 3, natoms, natoms], dtype=tf.complex64)
         prefactor = 4 * np.pi * e2 / omega_bohr
 
@@ -577,7 +587,7 @@ class HarmonicWithQ(Observable, Storable):
         # TODO: This "if-else" block could likely be replaced with the just the "if" block since the imaginary term I
         # think should be zero at Gamma, but we'd need to check that for sure.
         if qpoint is not None:
-            phase = np.exp(1j * np.pi * contract('ia,nma->inm', g_positions, distances_n))
+            phase = np.exp(1j * phase_prefactor * contract('ia,nma->inm', g_positions, distances_n))
 
             # The long range forces are the outer product of the effective charges, scaled by the phase term. We impose
             # Hermicity on cartesian axes by taking the average of M and M^T
@@ -592,7 +602,7 @@ class HarmonicWithQ(Observable, Storable):
             correction_matrix += lr_correction
 
         else:  # only the real part of the phase is taken at Gamma
-            phase = np.cos(np.pi * contract('ia,nma->inm', g_positions, distances_n))
+            phase = np.cos(phase_prefactor * contract('ia,nma->inm', g_positions, distances_n))
 
             # Also, this part of the correction is only applied on "diagonal" choices of atoms. (e.g. 00, 11, 22 etc)
             # The long range forces are an outer product of the effective charges, scaled by the exponential term.

--- a/kaldo/tests/test_nac_ewald_lambda_consistency.py
+++ b/kaldo/tests/test_nac_ewald_lambda_consistency.py
@@ -1,0 +1,115 @@
+"""
+Regression test for the non-analytic-correction (NAC) Ewald-parameter (Lambda)
+consistency between ``HarmonicWithQ.nac_dynmat`` (frequencies) and
+``HarmonicWithQ.nac_derivatives`` (group velocities).
+
+Background
+----------
+The NAC group-velocity operator ``nac_derivatives`` must be the exact q-gradient
+of the NAC dynamical matrix ``nac_dynmat`` that is added to the frequencies. Both
+evaluate a reciprocal-only Ewald dipole sum, whose value depends on the Ewald
+splitting parameter ``Lambda`` (it sets the Gaussian decay ``exp(-geg/(4*Lambda))``,
+the reciprocal cutoff ``geg/(4*Lambda) < gmax`` and the reciprocal-grid extent).
+Historically the two routines used *different* ``Lambda``:
+
+* ``nac_dynmat``      : normalises its reciprocal grid by ``c_recip = |inv(cell)[0,0]|``
+                       and uses ``Lambda = 1``  (validated: MgO matches matdyn.x to 0.00);
+* ``nac_derivatives`` : ``Lambda = (2*pi*Bohr/|cell[0,:]|)**2``.
+
+These give the same physical Gaussian width only when
+``|cell[0,:]| * |inv(cell)[0,0]| == 1`` (true for a cell whose first lattice
+vector is axis-aligned, e.g. wurtzite). For a primitive cell whose first lattice
+vector is *not* axis-aligned (e.g. an FCC primitive cell such as MgO) they differ,
+so ``nac_derivatives`` is NOT the gradient of ``nac_dynmat`` and the NAC group
+velocities are wrong (~8% for MgO).
+
+This is a REFERENCE-FREE test: it checks the internal identity
+``nac_derivatives == 1j * d/dq[nac_dynmat]`` by finite differences, against no
+external data. It FAILS on the unpatched code (MgO ~8%) and PASSES once the two
+routines share one Ewald parameter (``Lambda`` derived from ``c_recip`` in both).
+
+The FCC primitive cell (MgO) is the discriminating fixture; it ships with an
+in-file NAC block so no Born injection is needed.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kaldo.forceconstants import ForceConstants
+from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+# central-difference step in cartesian q (1/Angstrom); small enough that the
+# O(delta^2) truncation error sits well below the ~8% defect, large enough to
+# stay above the complex64 accumulation floor of nac_dynmat.
+FD_DELTA = 1e-3
+# gradient-consistency tolerance (%). unpatched MgO ~8.3%; patched ~0.01%.
+TOL_PCT = 1.0
+
+
+def _best_fit_reldiff(analytic, fd):
+    """Relative residual of ``analytic`` against ``fd`` after the best-fit complex
+    scale c (= <fd, analytic> / <fd, fd>). For a true gradient c == 1j and the
+    residual is the finite-difference floor."""
+    a, b = analytic.ravel(), fd.ravel()
+    c = np.vdot(b, a) / np.vdot(b, b)
+    resid = np.abs(analytic - c * fd).max() / (np.abs(analytic).max() + 1e-30)
+    return float(resid), c
+
+
+def _grad_consistency(second, cell, q=(0.04, 0.02, 0.0)):
+    q = np.array(q, float)
+    hq = HarmonicWithQ(q_point=q, second=second, storage="memory")
+
+    def nac_dyn(qf):
+        return np.array(hq.nac_dynmat(qpoint=np.array(qf, float), Lambda=None))
+
+    worst = 0.0
+    scale = None
+    for a in range(3):
+        # step cartesian q along axis a by FD_DELTA:  dq_frac = (delta/2pi) * cell[:, a]
+        dq = (FD_DELTA / (2 * np.pi)) * cell[:, a]
+        fd = (nac_dyn(q + dq) - nac_dyn(q - dq)) / (2 * FD_DELTA)
+        analytic = np.array(hq.nac_derivatives(direction=a, Lambda=None))
+        resid, c = _best_fit_reldiff(analytic, fd)
+        if resid > worst:
+            worst, scale = resid, c
+    return 100.0 * worst, scale
+
+
+@pytest.fixture(scope="module")
+def mgo_second():
+    src = Path(__file__).resolve().parent / "mgo"
+    fc = ForceConstants.from_folder(
+        folder=str(src), supercell=[5, 5, 5], only_second=True, format="qe-d3q"
+    )
+    assert "dielectric" in fc.second.atoms.info, "MgO NAC block was not read"
+    return fc.second
+
+
+def test_nac_velocity_operator_is_gradient_of_dynmat_fcc(mgo_second):
+    """FCC primitive (MgO): nac_derivatives must equal 1j * d/dq[nac_dynmat].
+
+    Fails on the unpatched code (the two routines use different Ewald Lambda ->
+    ~8% mismatch); passes once they share one Ewald parameter."""
+    cell = np.array(mgo_second.atoms.cell)
+    # the defect is triggered precisely when this product != 1
+    prod = float(np.linalg.norm(cell[0, :]) * abs(np.round(np.linalg.inv(cell), 12)[0, 0]))
+    assert abs(prod - 1.0) > 0.05, (
+        "MgO's first lattice vector is unexpectedly axis-aligned; this fixture "
+        "would not exercise the Lambda defect.")
+    reldiff_pct, scale = _grad_consistency(mgo_second, cell)
+    assert reldiff_pct < TOL_PCT, (
+        f"nac_derivatives is not the q-gradient of nac_dynmat: "
+        f"residual {reldiff_pct:.2f}% (best-fit scale {scale:.3f}). The two NAC "
+        f"routines use inconsistent Ewald Lambda.")
+
+
+def test_nac_gradient_scale_is_imaginary_unit(mgo_second):
+    """The best-fit scale between nac_derivatives and the finite-difference of
+    nac_dynmat must be ~1j (a genuine gradient, correct units), not merely
+    proportional."""
+    cell = np.array(mgo_second.atoms.cell)
+    _, scale = _grad_consistency(mgo_second, cell)
+    assert abs(scale - 1j) < 0.05, f"best-fit scale {scale:.3f} != 1j"

--- a/kaldo/tests/test_nac_nonfcc_phase.py
+++ b/kaldo/tests/test_nac_nonfcc_phase.py
@@ -1,0 +1,137 @@
+"""
+Regression test for the non-analytic-correction (NAC) Ewald phase on non-FCC
+polar cells.
+
+Background
+----------
+``HarmonicWithQ.nac_dynmat`` builds the reciprocal-space dipole phase in a
+normalized unit system and historically applied a prefactor of ``pi``. That
+reproduces the physical phase ``exp(i G.r)`` only when ``c_recip * a_max == 0.5``
+-- an identity that holds for an FCC primitive cell and for no other Bravais
+lattice. On any non-FCC polar cell the phase was applied at half its correct
+value, which (among other things) *splits symmetry-required degeneracies* that a
+physically correct NAC must preserve.
+
+These tests are deliberately reference-light: they assert physical invariants
+(a symmetry-mandated degeneracy that the half-phase breaks, and FCC agreement
+with the trusted MgO matdyn.x reference) rather than absolute hexagonal
+frequencies, because kaldo's hexagonal Wigner-Seitz interpolation at
+incommensurate q has separate, pre-existing differences vs matdyn.x (see the
+tolerance note in ``test_gan_hex_qe.py``).
+
+The hexagonal degeneracy test FAILS on the unpatched code (TA split ~36 cm^-1)
+and PASSES once the phase is evaluated in the physical ``exp(i G.r)`` convention.
+"""
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kaldo.forceconstants import ForceConstants
+from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+THZ_TO_CM = 33.3564095198152
+
+# Generic, physically reasonable wurtzite Born/dielectric constants. The GaN
+# fixture ships with NAC flag 'F' (no Born block); we inject a block so the
+# hexagonal NAC path is exercised. Exact values are immaterial to the symmetry
+# test -- the transverse-acoustic pair along Gamma-A is degenerate for *any*
+# C6v-consistent choice.
+GAN_EPS = [[5.35, 0.0, 0.0], [0.0, 5.35, 0.0], [0.0, 0.0, 5.48]]
+GAN_Z_GA = [[2.7, 0.0, 0.0], [0.0, 2.7, 0.0], [0.0, 0.0, 2.8]]
+GAN_Z_N = [[-2.7, 0.0, 0.0], [0.0, -2.7, 0.0], [0.0, 0.0, -2.8]]
+
+# MgO (FCC) matdyn.x reference (ships with an in-file NAC block); this is the
+# trusted control that must stay bit-for-bit unchanged by the fix.
+MGO_Q = [(0.3, 0.0, 0.3), (0.1, 0.0, 0.0), (0.15, 0.15, 0.15), (0.3, 0.1, 0.0)]
+MGO_MATDYN = [
+    [239.7640, 239.7640, 367.6916, 422.9322, 422.9322, 582.6500],
+    [77.0501, 77.0501, 135.2487, 389.4064, 389.4064, 691.1982],
+    [113.7407, 113.7407, 200.8237, 387.8639, 387.8639, 684.7630],
+    [203.9083, 210.4709, 344.9263, 386.7525, 394.9880, 643.5431],
+]
+
+
+def _inject_gan_born(src_dir, dst_dir):
+    """Copy the GaN QE fixture and turn on NAC by injecting a Born block."""
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(Path(src_dir) / "POSCAR", dst_dir / "POSCAR")
+    lines = (Path(src_dir) / "espresso.ifc2").read_text().splitlines()
+    flag_idx = next(i for i, ln in enumerate(lines[:12]) if ln.strip() in ("F", "T"))
+    fmt3 = lambda row: "".join("%18.10f" % x for x in row)
+    zeff = [GAN_Z_GA, GAN_Z_GA, GAN_Z_N, GAN_Z_N]
+    block = [" T"] + [fmt3(r) for r in GAN_EPS]
+    for ia in range(4):
+        block.append("%5d" % (ia + 1))
+        block.extend(fmt3(r) for r in zeff[ia])
+    new = lines[:flag_idx] + block + lines[flag_idx + 1:]
+    (dst_dir / "espresso.ifc2").write_text("\n".join(new) + "\n")
+
+
+@pytest.fixture(scope="module")
+def gan_nac_second(tmp_path_factory):
+    src = Path(__file__).resolve().parent / "gan"
+    dst = tmp_path_factory.mktemp("gan_nac") / "gan"
+    _inject_gan_born(src, dst)
+    fc = ForceConstants.from_folder(
+        folder=str(dst), supercell=[5, 5, 5], only_second=True, format="qe-d3q"
+    )
+    assert "dielectric" in fc.second.atoms.info, "Born block was not read"
+    return fc.second
+
+
+def _freqs_cm(second, q_point, is_unfolding=True):
+    hwq = HarmonicWithQ(
+        q_point=np.array(q_point, float), second=second,
+        is_unfolding=is_unfolding, storage="memory",
+    )
+    return np.sort(np.array(hwq.frequency).flatten()) * THZ_TO_CM
+
+
+def test_hexagonal_TA_degeneracy_along_gamma_A(gan_nac_second):
+    """Along Gamma-A (q || c) the two transverse-acoustic branches are
+    C6v-symmetry-required to be degenerate. The FCC-only half-phase splits
+    them by tens of cm^-1; the physical phase restores the degeneracy."""
+    f = _freqs_cm(gan_nac_second, (0.0, 0.0, 0.3), is_unfolding=True)
+    assert abs(f[0] - f[1]) < 1.0, f"TA pair split by {abs(f[0]-f[1]):.2f} cm^-1"
+    # the next (low optical) pair is likewise degenerate along Gamma-A
+    assert abs(f[2] - f[3]) < 1.0
+
+
+def test_hexagonal_NAC_is_active_and_shifts_spectrum(gan_nac_second):
+    """Sanity guard: with a Born block the NAC must actually move the spectrum
+    away from the NAC-off short-range result (otherwise the phase test is
+    vacuous)."""
+    on = _freqs_cm(gan_nac_second, (0.0, 0.0, 0.1), is_unfolding=True)
+    # NAC-off reference
+    import tensorflow as tf
+    orig = HarmonicWithQ.nac_dynmat
+    HarmonicWithQ.nac_dynmat = (
+        lambda self, qpoint=None, gmax=None, Lambda=None:
+        tf.zeros([len(self.second.atoms) * 3] * 2, dtype=tf.complex64)
+    )
+    try:
+        off = _freqs_cm(gan_nac_second, (0.0, 0.0, 0.1), is_unfolding=True)
+    finally:
+        HarmonicWithQ.nac_dynmat = orig
+    assert np.abs(on - off).max() > 5.0
+
+
+@pytest.fixture(scope="module")
+def mgo_second():
+    src = Path(__file__).resolve().parent / "mgo"
+    fc = ForceConstants.from_folder(
+        folder=str(src), supercell=[5, 5, 5], only_second=True, format="qe-d3q"
+    )
+    return fc.second
+
+
+@pytest.mark.parametrize("qi", range(len(MGO_Q)))
+def test_fcc_mgo_nac_unchanged_vs_matdyn(mgo_second, qi):
+    """FCC control: the fix must leave the FCC primitive cell bit-for-bit
+    unchanged (c_recip*a_max == 0.5 -> prefactor == pi), so MgO keeps matching
+    the trusted matdyn.x reference exactly."""
+    f = _freqs_cm(mgo_second, MGO_Q[qi], is_unfolding=True)
+    np.testing.assert_allclose(f, np.sort(MGO_MATDYN[qi]), atol=0.5)


### PR DESCRIPTION
Two bugs of NAC here:

1. FCC-only half-phase in `nac_dynmat` (frequencies).** The
   reciprocal-space Ewald dipole phase is evaluated at *half* its correct value
   for every non-FCC Bravais lattice, so LO/TO frequencies of non-cubic polar
   crystals are wrong.
2. Ewald parameter `Lambda` mismatch between `nac_dynmat` (frequencies)
   and `nac_derivatives` (group velocities).** The velocity operator uses a
   different Ewald `Lambda` than the dynamical matrix, so it is not the q-gradient
   of the matrix that goes into the frequencies; NAC group velocities are wrong
   for cells whose first lattice vector is not axis-aligned (e.g. FCC primitive).

@niklundgren Please check it out if your new code branch fixed this issue or not. I have provided the test case and you can check it out. 

---

## 1. phase is not right for non-FCC system. 

### Root cause
`nac_dynmat` builds the Ewald grid in a *normalized* unit system and applies a
phase prefactor of `pi`:

- `harmonic_with_q.py:527` — `positions_n = atoms.positions / atoms.cell[0,:].max()`
- `harmonic_with_q.py:529-530` — `reciprocal_n = inv(cell); reciprocal_n /= |reciprocal_n[0,0]|`
- `harmonic_with_q.py:580` / `:595` — `phase = exp(1j * pi * g_positions·distances_n)` (and the `cos` form at Γ)

The applied phase is `exp(i·[pi/(c_recip·a_max)]·G·Δr)`; the physical phase is
`exp(i·2π·G·Δr)`. These are equal **iff `c_recip·a_max = 0.5`**, an accident of the
FCC primitive cell. For simple-cubic / tetragonal / orthorhombic / hexagonal
`c_recip·a_max = 1.0`, so exactly **half** the phase is applied. The correct
convention already existed in the sibling `nac_derivatives`.

### The fix
Only the phase prefactor changes (`pi` → `2*pi*a_max*c_recip`), which equals the
physical `G·r` built from `2π·inv(cell/Bohr)` reciprocal vectors and Bohr
distances. **Bit-for-bit identical for FCC primitive cells** (`c_recip·a_max=0.5`
→ prefactor `pi`); restores the correct phase for all other lattices.

### Measured
- **FCC/MgO unchanged**: dynamical-matrix element delta ≤ 1.1e-13; MgO still
  matches QE `matdyn.x` to **0.00 cm⁻¹**.
- **Symmetry restored**: the C6v-required Γ–A transverse-acoustic degeneracy of
  wurtzite (GaN) goes from a **36.5 cm⁻¹** split (wrong) to **0.0 cm⁻¹**.


## 2. Ewald parameter `Lambda` mismatch between two branches of code

### Root cause
`nac_dynmat` and `nac_derivatives` both evaluate the reciprocal-only Ewald dipole
sum, whose value depends on the Ewald splitting parameter `Lambda` (it sets the
Gaussian decay `exp(-geg/(4*Lambda))/geg`, the reciprocal cutoff
`geg/(4*Lambda) < gmax`, and the reciprocal-grid extent `geg0 = 4*Lambda*gmax`).
The two routines used **different** `Lambda`:

| routine | used for | `Lambda` | line |
|---|---|---|---|
| `nac_dynmat` | frequencies | normalises reciprocal grid by `c_recip=\|inv(cell)[0,0]\|`, `Lambda = 1` | `:524` |
| `nac_derivatives` | group velocities | `(2*pi*Bohr/\|cell[0,:]\|)**2` | `:653` (`:643` pre-`0001`) |

These give the same physical Gaussian width only when
`|cell[0,:]| * |inv(cell)[0,0]| == 1`, i.e. when the first lattice vector is
axis-aligned. That holds for the wurtzite fixture (so its velocity `Lambda` was
accidentally correct) but **not** for an FCC primitive cell (MgO:
`|cell[0,:]|·|inv(cell)[0,0]| = 0.707 ≠ 1`). There `nac_derivatives` is **not**
the q-gradient of `nac_dynmat`.

`nac_dynmat`'s `Lambda = 1` is the validated one — it reproduces QE `matdyn.x`
for MgO to 0.00 cm⁻¹ (VALIDATION §1). Folding `nac_dynmat` onto the velocity
`Lambda` instead would move MgO frequencies **26–43 cm⁻¹** off `matdyn.x`, so the
frequency path must be preserved and the **velocity** path corrected.

### The fix
Introduce a shared helper `_ewald_reciprocal_scale(cell)` returning
`|inv(cell)[0,0]|`, used by **both** routines, and set `nac_derivatives`'s Ewald
parameter to `Lambda = (2*pi*c_recip*Bohr)**2` — the same physical Gaussian width
`nac_dynmat` already uses. `nac_derivatives` then becomes the exact analytic
gradient of `nac_dynmat` (finite-difference residual ~8% → <0.01%). The shared
helper means the two routines cannot drift apart again.

`nac_dynmat`'s numerical output is **bit-identical** (it sources `c_recip` from the
helper, whose value equals the previous inline expression), so **no phonon
frequency changes**; only NAC **group velocities** change.

### Measured
- **Gradient consistency** `nac_derivatives == 1j·d/dq[nac_dynmat]`, reference-free
  finite difference on the FCC/MgO fixture: **8.36% → 0.007%** residual.
- **Frequencies unchanged by `0002`**: MgO Δ = 8.5e-14 cm⁻¹, GaN Δ = 0.000 cm⁻¹
  (second bug fix never touches the frequency path).
- **Velocity operator change (the effect)**: MgO NAC velocity operator moves
  **3.67%**; larger for cells further from `|cell[0,:]|·|inv(cell)[0,0]| = 1`.


## Behavior change for users

Across the two commits, for **non-FCC polar** materials:

- **Frequencies shift** — caused by **`0001`** (the phase fix). Non-cubic polar
  LO/TO frequencies move (tens of cm⁻¹). FCC frequencies are unchanged.
- **Group velocities (and thus κ) shift** — caused by **`0001` (phase)** for
  non-FCC polar cells **and** by **`0002` (Ewald `Lambda`)** for any polar cell
  whose first lattice vector is not axis-aligned (including **FCC**, e.g. MgO
  ~few %).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-analytic correction calculations for crystals with varied cell orientations and non-FCC geometries.
  * Corrected reciprocal-space phase handling for finite-q and Gamma-point calculations.
  * Aligned NAC dynamical-matrix and derivative calculations for more consistent phonon velocities.

* **Tests**
  * Added regression coverage for hexagonal-cell degeneracies, active NAC frequency shifts, and existing FCC reference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->