### PR TITLE
Fix phonon frequencies at incommensurate q on non-diagonal tdep supercells

### DIFF
--- a/kaldo/grid.py
+++ b/kaldo/grid.py
@@ -109,22 +109,26 @@ class Grid:
 class NonDiagonalGrid(Grid):
     """Grid for a non-diagonal primitive-to-supercell tiling.
 
-    Stores an explicit ``replica_table`` (n_rep × 3) integer lattice vectors
-    in the primitive basis, already minimum-image-wrapped inside the
-    Wigner-Seitz cell of the supercell. Mimics the :class:`Grid` public
-    interface so downstream code (ForceConstant, HarmonicWithQ) can use it
-    interchangeably.
+    Stores an explicit ``replica_table`` of integer lattice vectors in the
+    primitive basis. The table holds either one norm-minimal representative
+    per Born-von-Karman congruence class (``det(M)`` rows) or, for
+    second-order TDEP loads since issue #297, one row per distinct per-pair
+    lattice vector found in the force-constant file (several rows of the
+    same class). Mimics the :class:`Grid` public interface so downstream
+    code (ForceConstant, HarmonicWithQ) can use it interchangeably.
 
     The ``is_wrapping`` flag on ``grid()`` and ``grid_index_to_id()`` is
     accepted for API compatibility with :class:`Grid` but is **always
-    treated as True**: the replica table is already minimum-image-wrapped
-    by construction.
+    treated as True**: the stored table is returned as-is.
     """
 
     def __init__(self, replica_table, M):
         self._replica_table = np.asarray(replica_table, dtype=int)
         self._M = np.asarray(M, dtype=float)
         self.grid_size = len(self._replica_table)
+        # Exact-row lookup: the dominant path when parsing per-pair IFC
+        # files (issue #297); misses fall back to congruence wrapping.
+        self._row_index = {tuple(int(x) for x in r): i for i, r in enumerate(self._replica_table)}
         # Synthesize a shape for the Grid base-class interface (used only
         # for n_replicas bookkeeping downstream).
         self.grid_shape = (self.grid_size, 1, 1)
@@ -134,7 +138,7 @@ class NonDiagonalGrid(Grid):
         return self._replica_table.copy()
 
     def grid(self, is_wrapping: bool = True):
-        # replica_table is already the minimum-image wrap
+        # the stored table is returned as-is
         return self._replica_table.copy()
 
     def unitary_grid(self, is_wrapping: bool = True):
@@ -143,15 +147,17 @@ class NonDiagonalGrid(Grid):
 
     def grid_index_to_id(self, cell_idx, is_wrapping: bool = True):
         cell_idx = np.asarray(cell_idx).astype(int)
-        if is_wrapping:
-            idx = wrap_lattice_vector_to_replica(
-                cell_idx, self._replica_table, self._M,
-            )
-            if idx < 0:
-                return np.array([], dtype=int)
-            return np.array([idx], dtype=int)
-        mask = (self._replica_table == cell_idx).all(axis=1)
-        return np.argwhere(mask).flatten()
+        hit = self._row_index.get(tuple(int(x) for x in cell_idx))
+        if hit is not None:
+            return np.array([hit], dtype=int)
+        if not is_wrapping:
+            return np.array([], dtype=int)
+        idx = wrap_lattice_vector_to_replica(
+            cell_idx, self._replica_table, self._M,
+        )
+        if idx < 0:
+            return np.array([], dtype=int)
+        return np.array([idx], dtype=int)
 
     def id_to_grid_index(self, id: int):
         return self._replica_table[int(id)].copy()
@@ -176,12 +182,15 @@ class NonDiagonalGrid(Grid):
 def wrap_lattice_vector_to_replica(R_prim_int, replica_table, M, tol=1e-4):
     """Find the replica index of a lattice vector R (integer primitive basis).
 
-    Wraps R through the non-diagonal supercell PBC and looks up the unique
-    replica entry. ``replica_table`` may be in either ``[0, 1)``-fractional
-    form or "Cartesian-norm-minimal" form; we test both candidates via
-    (a) the sc-fractional ``[0, 1)`` wrap and (b) nearby integer shifts of
-    M that could produce a norm-minimal representative. Returns the index
-    into ``replica_table`` or ``-1`` if no match.
+    ``replica_table`` may hold one row per congruence class (in
+    ``[0, 1)``-fractional or Cartesian-norm-minimal form) or several
+    congruent rows (per-pair tables, issue #297). An exact match on ``R``
+    wins over everything else, so per-pair tables resolve each vector to
+    its own row; only then the ``[0, 1)`` wrap and nearby integer shifts
+    of M are tried. For deduplicated class tables the priority is
+    irrelevant (at most one row is congruent to R), so their behavior is
+    unchanged. Returns the index into ``replica_table`` or ``-1`` if no
+    match.
 
     Pure SNF math — no TDEP-format dependencies. Used internally by
     :class:`NonDiagonalGrid` and by the TDEP non-diagonal IFC parsers.
@@ -197,9 +206,15 @@ def wrap_lattice_vector_to_replica(R_prim_int, replica_table, M, tol=1e-4):
     R_frac_prim_wrap = R_frac_sc_wrap @ M
     R_wrap_int = np.round(R_frac_prim_wrap).astype(int)
 
-    # Direct match (handles either-form table)
+    # Exact match first, over the whole table: when the table stores
+    # per-pair lattice vectors it may contain several rows of the same
+    # congruence class, and the entry's own R must win over a same-class
+    # sibling that happens to equal R's [0, 1) wrap.
     for idx, rep in enumerate(replica_table):
-        if np.array_equal(rep, R) or np.array_equal(rep, R_wrap_int):
+        if np.array_equal(rep, R):
+            return idx
+    for idx, rep in enumerate(replica_table):
+        if np.array_equal(rep, R_wrap_int):
             return idx
 
     # Otherwise enumerate nearby integer shifts (replica_table may be norm-minimal)

--- a/kaldo/grid.py
+++ b/kaldo/grid.py
@@ -117,9 +117,10 @@ class NonDiagonalGrid(Grid):
     same class). Mimics the :class:`Grid` public interface so downstream
     code (ForceConstant, HarmonicWithQ) can use it interchangeably.
 
-    The ``is_wrapping`` flag on ``grid()`` and ``grid_index_to_id()`` is
-    accepted for API compatibility with :class:`Grid` but is **always
-    treated as True**: the stored table is returned as-is.
+    ``grid()`` ignores ``is_wrapping`` and always returns the stored table
+    as-is. ``grid_index_to_id()`` always tries an exact row match first;
+    only the congruence-wrapping fallback used on a miss respects the
+    flag, returning an empty result when ``is_wrapping=False``.
     """
 
     def __init__(self, replica_table, M):

--- a/kaldo/interfaces/tdep_io.py
+++ b/kaldo/interfaces/tdep_io.py
@@ -209,7 +209,8 @@ def scan_tdep_lattice_vectors(fc_file):
     TDEP writes each neighbour entry with its own per-pair minimum-image
     lattice vector; the set of those vectors is the natural replica table
     for a Fourier interpolation that matches TDEP/phonopy/ALAMODE at
-    incommensurate q. Deterministic row-sorted order.
+    incommensurate q. Deterministic order: the home cell [0, 0, 0] comes
+    first (acoustic_sum_rule targets replica 0), remainder row-sorted.
     """
     vecs = []
     with open(fc_file) as f:

--- a/kaldo/interfaces/tdep_io.py
+++ b/kaldo/interfaces/tdep_io.py
@@ -203,7 +203,36 @@ def resolve_tdep_supercell(folder, supercell=(1, 1, 1), supercell_matrix=None):
     return uc, sc, inferred
 
 
-def build_nondiag_observable_kwargs(uc, sc):
+def scan_tdep_lattice_vectors(fc_file):
+    """Unique integer lattice vectors R appearing in a TDEP IFC2 file.
+
+    TDEP writes each neighbour entry with its own per-pair minimum-image
+    lattice vector; the set of those vectors is the natural replica table
+    for a Fourier interpolation that matches TDEP/phonopy/ALAMODE at
+    incommensurate q. Deterministic row-sorted order.
+    """
+    vecs = []
+    with open(fc_file) as f:
+        n_uc = int(_readline_or_raise(f, "IFC2 n_atoms").split()[0])
+        _readline_or_raise(f, "IFC2 cutoff")
+        for _ in range(n_uc):
+            n_nbr = int(_readline_or_raise(f, "IFC2 neighbour count").split()[0])
+            for _ in range(n_nbr):
+                _readline_or_raise(f, "IFC2 neighbour index")
+                lv = np.array(_readline_or_raise(f, "IFC2 lattice vector").split(), dtype=float)
+                vecs.append(np.round(lv).astype(int))
+                for _ in range(3):
+                    _readline_or_raise(f, "IFC2 tensor row")
+    table = np.unique(np.array(vecs, dtype=int), axis=0)
+    # acoustic_sum_rule targets dynmat[..., replica 0, ...] as the home
+    # cell; np.unique sorts signed vectors, so move [0, 0, 0] to the front.
+    zero = np.all(table == 0, axis=1)
+    if not zero.any():
+        raise ValueError(f"{fc_file}: no on-site [0, 0, 0] entry among the IFC2 lattice vectors")
+    return np.vstack([table[zero], table[~zero]])
+
+
+def build_nondiag_observable_kwargs(uc, sc, replica_table=None):
     """Build the shared kwargs SecondOrder/ThirdOrder/FourthOrder need to
     construct themselves on a non-diagonal SNF replica mapping.
 
@@ -222,15 +251,26 @@ def build_nondiag_observable_kwargs(uc, sc):
     (``is_acoustic_sum`` for SecondOrder, etc.), constructs the observable,
     then attaches ``_snf_mapping`` / ``_supercell_matrix`` / ``_replica_table``
     metadata via :func:`attach_snf_metadata` below.
+
+    ``replica_table`` overrides the grid's table (default: the det(M)
+    class table from the SNF mapping). SecondOrder passes the unique
+    per-pair lattice vectors from the IFC2 file (issue #297); in that case
+    the grid table and the ``_replica_table`` metadata intentionally
+    differ, and ``mapping["replica_id_of_sc"]`` indexes the class table,
+    never the grid. ``supercell`` in the returned dict is always
+    ``(len(replica_table), 1, 1)``.
     """
     from kaldo.grid import NonDiagonalGrid
     mapping = build_supercell_replica_mapping(uc, sc)
+    if replica_table is None:
+        replica_table = mapping["replica_table"]
+    replica_table = np.asarray(replica_table, dtype=int)
     nd_grid = NonDiagonalGrid(
-        replica_table=mapping["replica_table"], M=mapping["M"],
+        replica_table=replica_table, M=mapping["M"],
     )
-    rep_pos = (mapping["replica_table"] @ np.asarray(uc.cell))[:, None, :] \
+    rep_pos = (replica_table @ np.asarray(uc.cell))[:, None, :] \
               + np.asarray(uc.positions)[None, :, :]
-    n_rep = len(mapping["replica_table"])
+    n_rep = len(replica_table)
     return dict(
         atoms=uc,
         replicated_positions=rep_pos.reshape(-1, 3),

--- a/kaldo/observables/harmonic_with_q.py
+++ b/kaldo/observables/harmonic_with_q.py
@@ -1,4 +1,4 @@
-from kaldo.grid import wrap_coordinates, Grid
+from kaldo.grid import wrap_coordinates, Grid, NonDiagonalGrid
 from kaldo.observables.forceconstant import chi
 from kaldo.observables.observable import Observable
 import numpy as np
@@ -79,6 +79,12 @@ class HarmonicWithQ(Observable, Storable):
         # Arguments for specific physical assumptions
         self.is_amorphous = is_amorphous
         self.is_unfolding = is_unfolding
+        if is_unfolding and isinstance(getattr(second, '_direct_grid', None), NonDiagonalGrid):
+            raise NotImplementedError(
+                "is_unfolding assumes a diagonal (nx, ny, nz) supercell and is not "
+                "supported on the non-diagonal (SNF) path; the SNF tdep loader already "
+                "applies per-pair phases, so unfolding is not needed there."
+            )
         if not is_unfolding and getattr(second, '_snf_mapping', None) is None:
             # The commensurability heuristic reads self.supercell as an
             # (nx, ny, nz) grid; SNF observables linearize it to (n_rep, 1, 1),

--- a/kaldo/observables/secondorder.py
+++ b/kaldo/observables/secondorder.py
@@ -252,6 +252,7 @@ class SecondOrder(ForceConstant):
                     build_nondiag_observable_kwargs,
                     attach_snf_metadata,
                     resolve_tdep_supercell,
+                    scan_tdep_lattice_vectors,
                 )
                 from kaldo.grid import Grid
 
@@ -259,7 +260,12 @@ class SecondOrder(ForceConstant):
                 fc_file = os.path.join(folder, "infile.forceconstant")
 
                 if diagonal_supercell is None:
-                    kw = build_nondiag_observable_kwargs(uc, sc)
+                    # Per-pair lattice vectors from the file, not the det(M)
+                    # congruence classes: exact at commensurate q either way,
+                    # but only the per-pair table matches TDEP/phonopy/ALAMODE
+                    # between commensurate points (issue #297).
+                    kw = build_nondiag_observable_kwargs(
+                        uc, sc, replica_table=scan_tdep_lattice_vectors(fc_file))
                     mapping = kw.pop("_mapping")
                     d2 = parse_tdep_forceconstant(fc_file=fc_file, primitive=uc, grid=kw["grid"])
                     second_order = SecondOrder(value=d2, is_acoustic_sum=is_acoustic_sum, folder=folder, **kw)

--- a/kaldo/observables/thirdorder.py
+++ b/kaldo/observables/thirdorder.py
@@ -218,6 +218,10 @@ class ThirdOrder(ForceConstant):
                 fc_filename = os.path.join(folder, 'infile.forceconstant_thirdorder')
 
                 if diagonal_supercell is None:
+                    # Deliberately the det(M) class table, not the per-pair
+                    # table SecondOrder uses since issue #297: nothing pins
+                    # third-order interpolation and the two paths are
+                    # independent.
                     kw = build_nondiag_observable_kwargs(uc, sc)
                     mapping = kw.pop("_mapping")
                     third_ifcs = parse_tdep_third_forceconstant(fc_filename=fc_filename, primitive=uc,

--- a/kaldo/tests/test_nondiagonal_forceconstants.py
+++ b/kaldo/tests/test_nondiagonal_forceconstants.py
@@ -6,7 +6,8 @@ Covers:
   * ``from_folder(supercell_matrix=M)`` accepts a 3x3 integer matrix and
     loads IFC2/IFC3/IFC4 on a non-diagonal tiling (rhombo primitive +
     cubic conventional ssposcar).
-  * ``list_of_replicas`` returns the SNF Cartesian replica vectors.
+  * ``list_of_replicas`` returns the per-pair Cartesian lattice vectors
+    from the IFC2 file (the det(M) class table survives as metadata).
   * ``replicated_atoms`` carries the true ``M @ uc.cell`` supercell cell.
   * ``Conductivity.rta`` runs end-to-end on a non-diagonal fc.
   * ``IFC3`` / ``IFC4`` are stored at the right shapes.
@@ -153,21 +154,28 @@ def test_E4_fourth_order_nondiag_loads():
 
 @pytest.mark.skipif(not SI_PROD.exists(), reason="non-diagonal Si fixture unavailable")
 def test_E2_list_of_replicas_on_nondiagonal_si():
-    """fc.second.list_of_replicas must return the SNF Cartesian replica vectors.
+    """fc.second.list_of_replicas must return the per-pair Cartesian lattice vectors.
 
-    For non-diagonal Si production: 108 replicas, each in R = (a, b, c)_prim * uc_cell,
-    where (a,b,c) are integer triples from the SNF replica_table.
+    Since issue #297 the SNF second-order grid stores the unique per-pair
+    lattice vectors from the TDEP file (so Fourier interpolation matches
+    TDEP/phonopy between commensurate q). The det(M) = 108 BvK class table
+    survives as ``_replica_table`` metadata, and every per-pair vector must
+    reduce to one of its classes.
     """
     from kaldo.forceconstants import ForceConstants
     M = np.array([[3, -3, 3], [3, 3, -3], [-3, 3, 3]], dtype=int)
     fc = ForceConstants.from_folder(
         folder=str(SI_PROD), supercell_matrix=M, format="tdep", only_second=True,
     )
-    lr = fc.second.list_of_replicas  # (n_rep, 3) Cartesian
-    assert lr.shape == (108, 3)
-    # Compare to replica_table @ uc_cell
-    expected = fc.second._replica_table @ np.asarray(fc.atoms.cell)
-    np.testing.assert_allclose(lr, expected, atol=1e-10)
+    lr = fc.second.list_of_replicas  # (n_R, 3) Cartesian, per-pair vectors
+    grid_table = fc.second._direct_grid.grid(is_wrapping=True)
+    np.testing.assert_allclose(lr, grid_table @ np.asarray(fc.atoms.cell), atol=1e-10)
+    table = np.asarray(fc.second._replica_table)
+    assert table.shape == (108, 3)
+    Minv = np.linalg.inv(M.astype(float))
+    for r in grid_table:
+        diffs = (r - table) @ Minv
+        assert np.any(np.all(np.abs(diffs - np.rint(diffs)) < 1e-6, axis=1))
 
 
 @pytest.mark.skipif(not SI_TDEP_DIR.exists(), reason="si-tdep fixture missing")
@@ -264,8 +272,147 @@ def test_E1_from_folder_accepts_supercell_matrix_on_nondiagonal_si():
         format="tdep",
         only_second=True,  # E.4 will enable IFC3 non-diagonal
     )
-    # n_uc=2, n_replicas = det(M) = 108
     assert fc.n_atoms == 2
-    assert fc.n_replicas == 108
-    # The IFC2 tensor has the right shape for the non-diagonal storage
-    assert fc.second.value.shape == (1, 2, 3, 108, 2, 3)
+    # Since issue #297 the second-order replica axis holds the unique
+    # per-pair lattice vectors from the file, not the det(M) = 108 classes.
+    n_R = len(fc.second._direct_grid.grid(is_wrapping=True))
+    assert fc.n_replicas == n_R
+    assert fc.second.value.shape == (1, 2, 3, n_R, 2, 3)
+
+
+# ---------------------------------------------------------------------------
+# Issue #297: per-pair Fourier phases on the SNF path
+# ---------------------------------------------------------------------------
+
+_P_297 = np.array([[1, -1, 0], [0, 1, -1], [3, 3, 3]], dtype=int)  # det 9, anisotropic
+
+
+def _write_297_model(folder, onsite_defect=0.0):
+    """Write a self-contained TDEP model on the det-9 anisotropic tiling from
+    issue #297: a stable two-species spring crystal whose IFC2 entries carry
+    per-pair minimum-image lattice vectors, exactly as TDEP writes them.
+    Returns (uc, entries) with entries = [(a1, a2, R, phi), ...].
+    """
+    import ase
+    import ase.io
+    from ase.build import make_supercell
+
+    cell = np.array([[3.0, 0.0, 0.0], [0.3, 3.3, 0.0], [0.0, 0.2, 3.7]])
+    uc = ase.Atoms("SiGe", cell=cell, scaled_positions=[[0, 0, 0], [0.5, 0.5, 0.5]], pbc=True)
+    sc = make_supercell(uc, _P_297)
+    ase.io.write(str(folder / "infile.ucposcar"), uc, format="vasp")
+    ase.io.write(str(folder / "infile.ssposcar"), sc, format="vasp")
+
+    # Springs phi = -k(d) I between all pairs within rcut, keyed by the pair's
+    # strict minimum-image lattice vector under the supercell lattice
+    # (boundary ties are skipped so the file is unambiguous). On-site terms
+    # enforce the acoustic sum rule, so the model is dynamically stable.
+    rcut = 4.6
+    shifts = np.array([[a, b, c]
+                       for a in (-1, 0, 1) for b in (-1, 0, 1) for c in (-1, 0, 1)
+                       if (a, b, c) != (0, 0, 0)])
+    pos = uc.positions
+    entries = []
+    onsite = np.zeros((2, 3, 3))
+    for i in range(2):
+        for j in range(2):
+            for Ra in range(-4, 5):
+                for Rb in range(-4, 5):
+                    for Rc in range(-4, 5):
+                        R = np.array([Ra, Rb, Rc])
+                        v = pos[j] + R @ cell - pos[i]
+                        d = np.linalg.norm(v)
+                        if d < 1e-9 or d > rcut:
+                            continue
+                        alt = np.linalg.norm(pos[j] + ((R - shifts @ _P_297) @ cell) - pos[i], axis=1)
+                        if not np.all(d <= alt - 1e-9):
+                            continue
+                        k = 4.0 * np.exp(-d / 1.8)
+                        entries.append((i, j, R.copy(), -k * np.eye(3)))
+                        onsite[i] += k * np.eye(3)
+    for i in range(2):
+        entries.append((i, i, np.zeros(3, dtype=int), onsite[i] + onsite_defect * np.eye(3)))
+
+    with open(folder / "infile.forceconstant", "w") as f:
+        f.write("2\n100.0\n")
+        for i in range(2):
+            mine = [e for e in entries if e[0] == i]
+            f.write(f"{len(mine)}\n")
+            for _, a2, R, phi in mine:
+                f.write(f"{a2 + 1}\n")
+                f.write(" ".join(f"{x:.1f}" for x in R) + "\n")
+                for row in phi:
+                    f.write(" ".join(f"{x:.12f}" for x in row) + "\n")
+    return uc, entries
+
+
+def _per_pair_frequencies_thz(uc, entries, q):
+    """Reference frequencies from the per-pair Fourier sum, converted with
+    kaldo's own constants (value * mol/(10 J); nu = sqrt(lambda)/2pi)."""
+    from ase import units
+
+    masses = uc.get_masses()
+    n = len(uc)
+    D = np.zeros((n, 3, n, 3), dtype=complex)
+    for a1, a2, R, phi in entries:
+        D[a1, :, a2, :] += phi * np.exp(2j * np.pi * (q @ R)) / np.sqrt(masses[a1] * masses[a2])
+    lam = np.linalg.eigvalsh(D.reshape(3 * n, 3 * n) * units.mol / (10 * units.J))
+    return np.sign(lam) * np.sqrt(np.abs(lam)) / (2 * np.pi)
+
+
+def test_tdep_snf_matches_per_pair_reference_at_incommensurate_q(tmp_path):
+    """Issue #297: at q-points not commensurate with the ssposcar lattice the
+    plain path must reproduce the per-pair Fourier sum (the convention of
+    TDEP/phonopy/ALAMODE, whose vectors the file provides). The former
+    class-collapsed table was exact on the commensurate set but off by up
+    to ~85 cm^-1, with spurious imaginary acoustics, on band-path q.
+    """
+    from kaldo.forceconstants import ForceConstants
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+    uc, entries = _write_297_model(tmp_path)
+    fc = ForceConstants.from_folder(str(tmp_path), format="tdep", only_second=True)
+    for q in ([0.6667, 0.3333, 0.1111], [0.1234, 0.4321, 0.2468]):
+        q = np.array(q)
+        hq = HarmonicWithQ(q_point=q, second=fc.second, storage="memory")
+        got = np.sort(np.asarray(hq.frequency).ravel())
+        ref = np.sort(_per_pair_frequencies_thz(uc, entries, q))
+        np.testing.assert_allclose(got, ref, atol=1e-8)
+
+
+def test_is_unfolding_rejected_on_snf_path(tmp_path):
+    """is_unfolding assumes a diagonal (nx, ny, nz) supercell; on the SNF
+    path it silently returns garbage, so it must be refused."""
+    from kaldo.forceconstants import ForceConstants
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+    _write_297_model(tmp_path)
+    fc = ForceConstants.from_folder(str(tmp_path), format="tdep", only_second=True)
+    with pytest.raises(NotImplementedError, match="non-diagonal"):
+        HarmonicWithQ(q_point=np.array([0.1, 0.2, 0.3]), second=fc.second,
+                      is_unfolding=True, storage="memory")
+
+
+def test_tdep_snf_acoustic_sum_rule_targets_home_cell(tmp_path):
+    """is_acoustic_sum=True subtracts the total row sum of each atom at the
+    home cell (replica 0, R = [0, 0, 0]). On a per-pair table np.unique
+    would put a negative vector at index 0, attaching the correction to a
+    wrong lattice vector: invisible at Gamma (all phases are 1 there) but
+    wrong at any other q. With a deliberate on-site defect, ASR-corrected
+    loading of the defected file must reproduce the defect-free model.
+    """
+    from kaldo.forceconstants import ForceConstants
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+    uc, _ = _write_297_model(tmp_path, onsite_defect=0.05)
+    clean = tmp_path / "clean"
+    clean.mkdir()
+    _, entries_clean = _write_297_model(clean, onsite_defect=0.0)
+    fc = ForceConstants.from_folder(str(tmp_path), format="tdep",
+                                    only_second=True, is_acoustic_sum=True)
+    assert np.array_equal(fc.second._direct_grid.grid(is_wrapping=True)[0], [0, 0, 0])
+    q = np.array([0.1234, 0.4321, 0.2468])
+    hq = HarmonicWithQ(q_point=q, second=fc.second, storage="memory")
+    got = np.sort(np.asarray(hq.frequency).ravel())
+    ref = np.sort(_per_pair_frequencies_thz(uc, entries_clean, q))
+    np.testing.assert_allclose(got, ref, atol=1e-8)


### PR DESCRIPTION
Fixes #297.

The tdep SNF loader collapsed every IFC2 entry of a congruence class onto a single replica vector for the Fourier phases. That is exact at ssposcar-commensurate q, which is why the det-32 FCC case in the issue passes, but it interpolates badly in between: on the det-9 cell the acoustic branches came out wrong by up to 85 cm^-1, some imaginary, while phonopy reproduces the same files to 0.79 cm^-1. TDEP writes a minimum-image lattice vector for every pair, and phonopy/ALAMODE phase each pair with its own vector; we were throwing that information away.

This stores the second order on the unique per-pair vectors read from the file instead, so the plain path computes the per-pair Fourier sum. On the issue's repro bundle mp-7 goes from 85.1 to 0.76 cm^-1 against the ALAMODE reference and mp-1000 stays exact (0.000).

A few things that surfaced along the way: [0, 0, 0] is forced to replica 0, since acoustic_sum_rule targets slot 0 as the home cell and np.unique would put a negative vector there (a misplaced correction cancels at Gamma and is wrong at every other q). is_unfolding now raises on the SNF path instead of returning garbage; it assumes a diagonal tiling, and the per-pair table already is the minimum-image interpolant it would reconstruct. The det(M) class table stays attached as metadata, and third/fourth order are unchanged. NonDiagonalGrid gained an exact-row dict lookup so parsing big IFC2 files stays linear.

New tests: a self-contained det-9 model pinning the plain path against a per-pair reference at incommensurate q, an ASR placement test with a deliberate sum-rule defect (both fail on main), and the unfolding guard. E1/E2 are updated to the new contract. If you have storage='numpy' runs on non-diagonal cells, regenerate them: cached per-q artifacts predate the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved non-diagonal lattice-vector resolution using exact-match-first replica lookups.
  * Added TDEP IFC2 scanning to read, round, deduplicate, and deterministically order per-pair replica lattice vectors.
  * Non-diagonal TDEP workflows now consistently use the selected per-pair replica table for interpolation setup.

* **Bug Fixes**
  * Prevents unsupported unfolding on the SNF/non-diagonal path by raising a clear error.

* **Tests**
  * Updated non-diagonal expectations and added coverage for incommensurate q behavior, unfolding rejection, and acoustic sum-rule targeting (Issue `#297`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->