### PR TITLE
Parallelize cumulant F1/F2, harmonic, and Energy Sampling

### DIFF
--- a/kaldo/cumulant/_harmonic_worker.py
+++ b/kaldo/cumulant/_harmonic_worker.py
@@ -1,0 +1,34 @@
+"""Phase-1 frequency worker: ``HarmonicWithQ`` over a chunk of q-points.
+
+Spawn workers import this module to unpickle ``freq_q_chunk``. TensorFlow
+comes in through ``HarmonicWithQ``; that is the same Phonons dynmat path
+used serially, just sharded across ``n_workers``.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+_STATE = {}
+
+
+def init_freq_worker(n_threads, second, hwq_kwargs):
+    """Process-pool initializer: thread cap + pickled ``SecondOrder``."""
+    from kaldo.parallel.executor import _init_worker_thread_caps
+    _init_worker_thread_caps(int(n_threads))
+    _STATE["second"] = second
+    _STATE["kwargs"] = hwq_kwargs
+
+
+def freq_q_chunk(q_points):
+    """Frequencies (n_q_chunk, n_modes) in THz for ``q_points``."""
+    from kaldo.observables.harmonic_with_q import HarmonicWithQ
+
+    second = _STATE["second"]
+    kw = _STATE["kwargs"]
+    q_points = np.asarray(q_points)
+    n_modes = int(second.n_modes)
+    out = np.empty((q_points.shape[0], n_modes), dtype=np.float64)
+    for i, q in enumerate(q_points):
+        hwq = HarmonicWithQ(q_point=q, second=second, **kw)
+        out[i] = np.asarray(hwq.frequency).reshape(-1)
+    return out

--- a/kaldo/cumulant/_phase5_worker.py
+++ b/kaldo/cumulant/_phase5_worker.py
@@ -1,0 +1,144 @@
+"""Phase-5 config worker (one LAMMPS per process).
+
+This module is imported by spawn workers. It must not import
+``kaldo.cumulant.thermodynamics`` or ``kaldo.forceconstants`` itself; those
+pull TensorFlow. Parent-package ``__init__`` may still run on spawn — that
+is a separate issue. Keep *this* file's imports limited to sampler,
+contractors, the energy evaluator, and ASE.
+
+Each worker owns:
+  * its own ``LAMMPSlib`` / ASE calculator + ``BatchEnergyEvaluator``
+  * a jumped RNG stream on a pickled ``SCSampler``
+  * in-process V2/V3/V4 (no inner thread pool)
+"""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+from kaldo.cumulant._energy_evaluator import BatchEnergyEvaluator
+
+
+def _lammps_log_path(spec=None):
+    """Per-process LAMMPS log so n_workers>1 does not collide on one file."""
+    log_dir = None
+    if spec:
+        log_dir = spec.get("log_dir")
+    if not log_dir:
+        log_dir = os.environ.get("KALDO_CUMULANT_LAMMPS_LOG_DIR", "/tmp")
+    os.makedirs(log_dir, exist_ok=True)
+    return os.path.join(log_dir, f"cumulant_thermo_lammps_{os.getpid()}.log")
+
+
+def _load_contractors(spec):
+    """Unpickle a tiny contractor table, or rebuild from ``tdep_folder``.
+
+    Production Phase-5 shards must not pickle ``phi4`` into every worker
+    (hundreds of MB per process). Pass ``tdep_folder`` and rebuild locally.
+    Tests may still ship a small ``contractors`` object.
+    """
+    contractors = spec.get("contractors")
+    if contractors is None:
+        folder = spec.get("tdep_folder")
+        if not folder:
+            raise ValueError("Phase-5 worker needs contractors= or tdep_folder=")
+        from .contractors import SCContractors
+        contractors = SCContractors.from_tdep_folder(
+            folder, include_fourth=spec.get("include_fourth", True),
+        )
+    return contractors
+
+
+def _instantiate_calculator(calculator):
+    """Return a calculator instance from a class, factory, or live instance."""
+    if calculator is None:
+        return None
+    if isinstance(calculator, type):
+        return calculator()
+    # ASE calculators have ``calculate``; factories are bare callables.
+    if callable(calculator) and not hasattr(calculator, "calculate"):
+        return calculator()
+    return calculator
+
+
+def build_energy_eval(spec):
+    """Build a worker-local ``BatchEnergyEvaluator`` from picklable spec fields."""
+    from ase import Atoms
+
+    atoms = Atoms(
+        spec["species"],
+        positions=spec["eq"],
+        cell=spec["cell"],
+        pbc=True,
+    )
+    if spec.get("lammps_cmds") is not None:
+        from ase.calculators.lammpslib import LAMMPSlib
+
+        kwargs = dict(spec.get("lammps_kwargs") or {})
+        atoms.calc = LAMMPSlib(
+            lmpcmds=list(spec["lammps_cmds"]),
+            keep_alive=True,
+            log_file=_lammps_log_path(spec),
+            **kwargs,
+        )
+    else:
+        atoms.calc = _instantiate_calculator(spec["calculator"])
+        if atoms.calc is None:
+            raise ValueError("Phase-5 worker needs lammps_cmds= or calculator=")
+    return BatchEnergyEvaluator(atoms, spec["eq"])
+
+
+def run_phase5_loop(nconf, sampler, contractors, energy_eval, verbose=False, logger=None):
+    """Serial Phase-5 loop over ``nconf`` draws. Used by n_workers=1 and by each worker."""
+    V = np.zeros(nconf)
+    V2 = np.zeros(nconf)
+    V3 = np.zeros(nconf)
+    V4 = np.zeros(nconf)
+    V2_tilde = np.zeros(nconf)
+    dV2_tilde_dT = np.zeros(nconf)
+    import time
+    t0 = time.time()
+    for n in range(nconf):
+        u, z = sampler.draw_with_z()
+        V[n] = energy_eval.energy(u)
+        V2[n] = contractors.V2(u)
+        V3[n] = contractors.V3(u)
+        V4[n] = contractors.V4(u)
+        V2_tilde[n], dV2_tilde_dT[n] = sampler.V2_tilde_and_dT_from_z(z)
+        if verbose and logger is not None and (n + 1) % max(1, nconf // 10) == 0:
+            logger.info(f"  n={n+1}/{nconf}  ({time.time()-t0:.1f}s)")
+    return V, V2, V3, V4, V2_tilde, dV2_tilde_dT
+
+
+def eval_u_chunk(spec):
+    """Evaluate V/V2/V3/V4 on a fixed list of displacements (no RNG).
+
+    Used by tests so parallel vs serial can match bit-for-bit on contractors
+    and energy, independent of jumped sample streams.
+    """
+    contractors = _load_contractors(spec)
+    energy_eval = build_energy_eval(spec)
+    us = spec["us"]
+    n = len(us)
+    V = np.empty(n)
+    V2 = np.empty(n)
+    V3 = np.empty(n)
+    V4 = np.empty(n)
+    for i, u in enumerate(us):
+        V[i] = energy_eval.energy(u)
+        V2[i] = contractors.V2(u)
+        V3[i] = contractors.V3(u)
+        V4[i] = contractors.V4(u)
+    return V, V2, V3, V4
+
+
+def run_phase5_chunk(spec):
+    """Process-pool entry: jumped RNG, own LAMMPS, serial contractors."""
+    contractors = _load_contractors(spec)
+    sampler = spec["sampler"]
+    sampler.rng = np.random.Generator(
+        np.random.PCG64(spec["seed"]).jumped(int(spec["worker_id"]))
+    )
+    energy_eval = build_energy_eval(spec)
+    return run_phase5_loop(int(spec["n_local"]), sampler, contractors, energy_eval)

--- a/kaldo/cumulant/_phase5_worker.py
+++ b/kaldo/cumulant/_phase5_worker.py
@@ -89,7 +89,8 @@ def build_energy_eval(spec):
     return BatchEnergyEvaluator(atoms, spec["eq"])
 
 
-def run_phase5_loop(nconf, sampler, contractors, energy_eval, verbose=False, logger=None):
+def run_phase5_loop(nconf, sampler, contractors, energy_eval, verbose=False, logger=None,
+                    progress=None, progress_index=None):
     """Serial Phase-5 loop over ``nconf`` draws. Used by n_workers=1 and by each worker."""
     V = np.zeros(nconf)
     V2 = np.zeros(nconf)
@@ -99,6 +100,7 @@ def run_phase5_loop(nconf, sampler, contractors, energy_eval, verbose=False, log
     dV2_tilde_dT = np.zeros(nconf)
     import time
     t0 = time.time()
+    progress_every = max(1, min(10, nconf // 100))
     for n in range(nconf):
         u, z = sampler.draw_with_z()
         V[n] = energy_eval.energy(u)
@@ -106,6 +108,8 @@ def run_phase5_loop(nconf, sampler, contractors, energy_eval, verbose=False, log
         V3[n] = contractors.V3(u)
         V4[n] = contractors.V4(u)
         V2_tilde[n], dV2_tilde_dT[n] = sampler.V2_tilde_and_dT_from_z(z)
+        if progress is not None and ((n + 1) % progress_every == 0 or n + 1 == nconf):
+            progress[progress_index, 0] = n + 1
         if verbose and logger is not None and (n + 1) % max(1, nconf // 10) == 0:
             logger.info(f"  n={n+1}/{nconf}  ({time.time()-t0:.1f}s)")
     return V, V2, V3, V4, V2_tilde, dV2_tilde_dT
@@ -141,4 +145,19 @@ def run_phase5_chunk(spec):
         np.random.PCG64(spec["seed"]).jumped(int(spec["worker_id"]))
     )
     energy_eval = build_energy_eval(spec)
-    return run_phase5_loop(int(spec["n_local"]), sampler, contractors, energy_eval)
+    progress_shm = None
+    progress = None
+    if spec.get("progress_shm_name") is not None:
+        from multiprocessing import shared_memory
+        progress_shm = shared_memory.SharedMemory(name=spec["progress_shm_name"])
+        progress = np.ndarray(
+            tuple(spec["progress_shape"]), dtype=np.int64, buffer=progress_shm.buf,
+        )
+    try:
+        return run_phase5_loop(
+            int(spec["n_local"]), sampler, contractors, energy_eval,
+            progress=progress, progress_index=int(spec["worker_id"]),
+        )
+    finally:
+        if progress_shm is not None:
+            progress_shm.close()

--- a/kaldo/cumulant/contractors.py
+++ b/kaldo/cumulant/contractors.py
@@ -26,10 +26,7 @@ with u in Angstroms and phi^{(n)} in eV/A^n; returns V in eV.
 """
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
-import os
 from pathlib import Path
-from typing import Iterable
 
 import h5py
 import numpy as np
@@ -156,85 +153,29 @@ class SCContractors:
 
     def V3(self, u_flat):
         """V_3 in eV."""
-        return _vn_threaded(
-            self._phi3_9_3,
-            u_flat[self.a1_3], u_flat[self.a2_3], u_flat[self.a3_3], None,
-            order=3,
-        )
+        u1 = u_flat[self.a1_3]
+        u2 = u_flat[self.a2_3]
+        u3 = u_flat[self.a3_3]
+        n = u1.shape[0]
+        if n == 0:
+            return 0.0
+        t = np.matmul(self._phi3_9_3, u3[:, :, None])[..., 0]
+        t = np.matmul(t.reshape(n, 3, 3), u2[:, :, None])[..., 0]
+        return float((t * u1).sum()) / 6.0
 
     def V4(self, u_flat):
-        """V_4 in eV.
-
-        Chunks the flat quartet table across threads (stdlib
-        ``ThreadPoolExecutor``), same idea as LDT's ``@tasks for a1`` over
-        IFC interactions. This is *shared-memory* parallelism over the
-        tensor — not ``kaldo.parallel`` process pools (those pickle whole
-        work items; shipping ``phi4`` every call would dominate).
-        """
-        return _vn_threaded(
-            self._phi4_27_3,
-            u_flat[self.a1_4], u_flat[self.a2_4], u_flat[self.a3_4], u_flat[self.a4_4],
-            order=4,
-        )
-
-
-def _n_contract_workers(n_terms):
-    """Worker count for IFC-table threading (Julia-style naive split)."""
-    # Prefer user/OpenMP hint when set, else all CPUs — same spirit as
-    # ``kaldo.parallel.get_executor(n_workers=None)``.
-    omp = os.environ.get("OMP_NUM_THREADS") or os.environ.get("KALDO_CONTRACT_THREADS")
-    if omp is not None:
-        try:
-            n_cpu = max(1, int(omp))
-        except ValueError:
-            n_cpu = os.cpu_count() or 1
-    else:
-        n_cpu = os.cpu_count() or 1
-    # Need enough terms per worker that thread overhead doesn't dominate.
-    return max(1, min(n_cpu, n_terms // 4096))
-
-
-def _v3_slice(phi_9_3, u1, u2, u3, i0, i1):
-    m = i1 - i0
-    if m <= 0:
-        return 0.0
-    t = np.matmul(phi_9_3[i0:i1], u3[i0:i1, :, None])[..., 0]
-    t = np.matmul(t.reshape(m, 3, 3), u2[i0:i1, :, None])[..., 0]
-    return float((t * u1[i0:i1]).sum()) / 6.0
-
-
-def _v4_slice(phi_27_3, u1, u2, u3, u4, i0, i1):
-    """Batched matmul contraction for quartets ``[i0:i1)``; returns sum/24."""
-    m = i1 - i0
-    if m <= 0:
-        return 0.0
-    t = np.matmul(phi_27_3[i0:i1], u4[i0:i1, :, None])[..., 0]
-    t = np.matmul(t.reshape(m, 9, 3), u3[i0:i1, :, None])[..., 0]
-    t = np.matmul(t.reshape(m, 3, 3), u2[i0:i1, :, None])[..., 0]
-    return float((t * u1[i0:i1]).sum()) / 24.0
-
-
-def _vn_threaded(phi_view, u1, u2, u3, u4, order):
-    """Split flat IFC table across threads and sum slice contractions."""
-    n = u1.shape[0]
-    if n == 0:
-        return 0.0
-    n_workers = _n_contract_workers(n)
-    if order == 3:
-        slice_fn = lambda i0, i1: _v3_slice(phi_view, u1, u2, u3, i0, i1)
-    else:
-        slice_fn = lambda i0, i1: _v4_slice(phi_view, u1, u2, u3, u4, i0, i1)
-
-    if n_workers == 1:
-        return slice_fn(0, n)
-
-    bounds = np.linspace(0, n, n_workers + 1, dtype=np.int64)
-    with ThreadPoolExecutor(max_workers=n_workers) as pool:
-        futs = [
-            pool.submit(slice_fn, int(bounds[i]), int(bounds[i + 1]))
-            for i in range(n_workers)
-        ]
-        return float(sum(f.result() for f in futs))
+        """V_4 in eV."""
+        u1 = u_flat[self.a1_4]
+        u2 = u_flat[self.a2_4]
+        u3 = u_flat[self.a3_4]
+        u4 = u_flat[self.a4_4]
+        n = u1.shape[0]
+        if n == 0:
+            return 0.0
+        t = np.matmul(self._phi4_27_3, u4[:, :, None])[..., 0]
+        t = np.matmul(t.reshape(n, 9, 3), u3[:, :, None])[..., 0]
+        t = np.matmul(t.reshape(n, 3, 3), u2[:, :, None])[..., 0]
+        return float((t * u1).sum()) / 24.0
 
 
 # ---------------------------------------------------------------------------

--- a/kaldo/cumulant/free_energy.py
+++ b/kaldo/cumulant/free_energy.py
@@ -16,7 +16,10 @@ Physics formulas follow Julia's conventions exactly:
 """
 from __future__ import annotations
 
+import os
 import time
+from concurrent.futures import as_completed
+from multiprocessing import shared_memory
 
 import numpy as np
 
@@ -132,8 +135,326 @@ def build_psi4_realspace_v(QD, q1_cart, q2_cart):
     return A
 
 
+# ---------------------------------------------------------------------------
+# Process-pool q1 reduction: SharedMemory for flattened IFCs (QD/TD) and
+# other large read-only arrays. Nested quartet/triplet lists never leave
+# the parent. Each worker maps the same blocks once via initializer.
+# ---------------------------------------------------------------------------
+
+_QD_ARRAY_KEYS = ('a1', 'a2', 'a3', 'a4', 'lv2c', 'lv3c', 'lv4c', 'ifc')
+_TD_ARRAY_KEYS = ('a1', 'a2', 'a3', 'lv2c', 'lv3c', 'ifc')
+
+# Filled by _init_q1_worker in process-pool children; unused on the serial path.
+_WORKER_Q1 = None
+
+
+def _check_n_workers(n_workers):
+    if n_workers is not None and n_workers < 1:
+        raise ValueError(f"n_workers must be >= 1 or None, got {n_workers}")
+
+
+def _prefix_table(prefix, table, keys):
+    return {f'{prefix}.{k}': table[k] for k in keys}
+
+
+def _unprefix_table(prefix, arrays, keys, nb):
+    out = {k: arrays[f'{prefix}.{k}'] for k in keys}
+    out['nb'] = nb
+    return out
+
+
+def _create_shm_array(arr):
+    arr = np.ascontiguousarray(arr)
+    nbytes = int(arr.nbytes)
+    shm = shared_memory.SharedMemory(create=True, size=max(nbytes, 1))
+    if nbytes:
+        view = np.ndarray(arr.shape, dtype=arr.dtype, buffer=shm.buf)
+        view[:] = arr
+    return {
+        'name': shm.name,
+        'shape': tuple(int(s) for s in arr.shape),
+        'dtype': np.dtype(arr.dtype).str,
+        'nbytes': nbytes,
+    }, shm
+
+
+def _view_shm_array(meta, hold):
+    shm = shared_memory.SharedMemory(name=meta['name'])
+    hold.append(shm)
+    if meta['nbytes'] == 0:
+        return np.empty(meta['shape'], dtype=np.dtype(meta['dtype']))
+    arr = np.ndarray(meta['shape'], dtype=np.dtype(meta['dtype']), buffer=shm.buf)
+    try:
+        arr.setflags(write=False)
+    except ValueError:
+        pass
+    return arr
+
+
+class _SharedArrayStore:
+    """Parent-owned SharedMemory blocks for a dict of ndarrays."""
+
+    def __init__(self, arrays):
+        self._shms = []
+        self.spec = {}
+        try:
+            for key, arr in arrays.items():
+                meta, shm = _create_shm_array(arr)
+                self._shms.append(shm)
+                self.spec[key] = meta
+        except Exception:
+            self.close_and_unlink()
+            raise
+
+    def close_and_unlink(self):
+        for shm in self._shms:
+            try:
+                shm.close()
+            except Exception:
+                pass
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception:
+                pass
+        self._shms.clear()
+
+
+def _init_q1_worker(thread_cap, spec, scalars):
+    from kaldo.parallel.executor import _init_worker_thread_caps
+    _init_worker_thread_caps(int(thread_cap))
+    global _WORKER_Q1
+    hold = []
+    arrays = {k: _view_shm_array(meta, hold) for k, meta in spec.items()}
+    _WORKER_Q1 = {'arrays': arrays, 'scalars': scalars, '_hold': hold}
+
+
+def _q1_chunk_worker(iq1_list):
+    key = _WORKER_Q1['scalars']['_accumulate']
+    return _ACCUMULATORS[key](iq1_list, _WORKER_Q1['arrays'], _WORKER_Q1['scalars'])
+
+
+def _run_parallel_q1(accumulate_key, q1_indices, n_workers, arrays, scalars):
+    """Map q1 chunks onto processes; reduce (F, S, Cv) with +."""
+    from kaldo.parallel import get_executor, is_parallel
+
+    iq1s = [int(i) for i in q1_indices]
+    if not is_parallel(n_workers):
+        return _ACCUMULATORS[accumulate_key](iq1s, arrays, scalars)
+
+    n_cpu = n_workers if n_workers is not None else (os.cpu_count() or 1)
+    n_chunks = max(1, min(int(n_cpu), len(iq1s)))
+    chunks = [
+        c.tolist() for c in np.array_split(np.asarray(iq1s, dtype=int), n_chunks)
+        if c.size
+    ]
+    payload = dict(scalars)
+    payload['_accumulate'] = accumulate_key
+    store = _SharedArrayStore(arrays)
+    F = S = Cv = 0.0
+    try:
+        with get_executor(
+            backend='process',
+            n_workers=len(chunks),
+            initializer=_init_q1_worker,
+            initargs=(1, store.spec, payload),
+        ) as executor:
+            futures = [executor.submit(_q1_chunk_worker, chunk) for chunk in chunks]
+            for i, fut in enumerate(as_completed(futures), 1):
+                f, s, cv = fut.result()
+                F += f
+                S += s
+                Cv += cv
+                logging.info(f"  q1-chunk {i}/{len(chunks)}")
+    finally:
+        store.close_and_unlink()
+    return F, S, Cv
+
+
+def _accumulate_f1_q1s(iq1_list, arrays, scalars):
+    cart = arrays['cart']
+    M = arrays['M']
+    inv_w = arrays['inv_w']
+    two_np1 = arrays['two_np1']
+    dn_tab = arrays['dn_tab']
+    ddn_tab = arrays['ddn_tab']
+    ok = arrays['ok']
+    QD = _unprefix_table('qd', arrays, _QD_ARRAY_KEYS, scalars['qd_nb'])
+    q1_weights = scalars['q1_weights']
+    nq = scalars['nq']
+    T_K = scalars['T_K']
+    log_every = scalars.get('log_every')
+    n_q1 = len(iq1_list)
+    t0 = time.time()
+    F1_acc = 0.0
+    S1_acc = 0.0
+    Cv1_acc = 0.0
+    for _i, iq1 in enumerate(iq1_list):
+        q1c = cart[iq1]
+        M1 = M[iq1]
+        inv_w1 = inv_w[iq1]
+        two1 = two_np1[iq1]
+        dn1 = dn_tab[iq1]
+        ddn1 = ddn_tab[iq1]
+        ok1 = ok[iq1]
+        w1 = q1_weights[iq1]
+        for iq2 in range(nq):
+            q2c = cart[iq2]
+            A = build_psi4_realspace_v(QD, q1c, q2c)
+            T = np.einsum("kab,abcd->kcd", M1, A)
+            Psi4 = np.einsum("kcd,lcd->kl", T, M[iq2])
+            psi_re = np.real(Psi4)
+            mask = ok1[:, None] & ok[iq2][None, :]
+            inv_w_prod = inv_w1[:, None] * inv_w[iq2][None, :]
+
+            two2 = two_np1[iq2][None, :]
+            dn2 = dn_tab[iq2][None, :]
+            ddn2 = ddn_tab[iq2][None, :]
+            f_w = two1[:, None] * two2 * inv_w_prod
+            s_w = -(2.0 * dn1[:, None] * two2 + two1[:, None] * 2.0 * dn2) * inv_w_prod
+            cv_w = -(2.0 * ddn1[:, None] * two2 + 2.0 * ddn2 * two1[:, None]
+                     + 8.0 * dn1[:, None] * dn2) * T_K * inv_w_prod
+
+            F1_acc += w1 * (psi_re * f_w * mask).sum()
+            S1_acc += w1 * (psi_re * s_w * mask).sum()
+            Cv1_acc += w1 * (psi_re * cv_w * mask).sum()
+        if log_every and (_i + 1) % log_every == 0:
+            logging.info(f"  q1={_i+1}/{n_q1}  elapsed={time.time()-t0:.1f}s")
+    return F1_acc, S1_acc, Cv1_acc
+
+
+def _accumulate_f2_q1s(iq1_list, arrays, scalars):
+    cart = arrays['cart']
+    egvs = arrays['egvs']
+    omegas = arrays['omegas']
+    frac_rounded = arrays['frac_rounded']
+    lookup = arrays['lookup']
+    ok_tab = arrays['ok_tab']
+    TD = _unprefix_table('td', arrays, _TD_ARRAY_KEYS, scalars['td_nb'])
+    q1_weights = scalars['q1_weights']
+    nq = scalars['nq']
+    nx = scalars['nx']
+    ny = scalars['ny']
+    nz = scalars['nz']
+    T_K = scalars['T_K']
+    is_classic = scalars['is_classic']
+    kT = scalars['kT']
+    sigma_table = arrays.get('sigma_table')
+    n_tab = arrays.get('n_tab')
+    dn_tab = arrays.get('dn_tab')
+    ddn_tab = arrays.get('ddn_tab')
+    log_every = scalars.get('log_every')
+    n_q1 = len(iq1_list)
+    t0 = time.time()
+    F2 = 0.0
+    S2 = 0.0
+    Cv2 = 0.0
+    for _i, iq1 in enumerate(iq1_list):
+        i1, j1, k1 = frac_rounded[iq1]
+        e1 = egvs[iq1]
+        w1 = omegas[iq1]
+        ok1 = ok_tab[iq1]
+        w_q1 = q1_weights[iq1]
+        for iq2 in range(nq):
+            i2, j2, k2 = frac_rounded[iq2]
+            i3 = (-i1 - i2) % nx
+            j3 = (-j1 - j2) % ny
+            k3 = (-k1 - k2) % nz
+            iq3 = lookup[i3, j3, k3]
+            q2c = cart[iq2]
+            q3c = cart[iq3]
+
+            A = build_psi3_realspace(TD, q2c, q3c)
+
+            e2 = egvs[iq2]
+            e3 = egvs[iq3]
+            w2 = omegas[iq2]
+            w3 = omegas[iq3]
+            ok2 = ok_tab[iq2]
+            ok3 = ok_tab[iq3]
+
+            e1c = np.conj(e1)
+            e2c = np.conj(e2)
+            e3c = np.conj(e3)
+            T1 = np.einsum("abc,ak->kbc", A, e1c)
+            T2 = np.einsum("kbc,bl->klc", T1, e2c)
+            Psi3 = np.einsum("klc,cm->klm", T2, e3c)
+            psisq = np.abs(Psi3) ** 2
+
+            w1_ = w1[:, None, None]
+            w2_ = w2[None, :, None]
+            w3_ = w3[None, None, :]
+            mask = ok1[:, None, None] & ok2[None, :, None] & ok3[None, None, :]
+
+            inv_w_prod = np.zeros_like(psisq)
+            inv_w_prod[mask] = 1.0 / (w1_ * w2_ * w3_)[mask]
+
+            if is_classic:
+                w_prod = w1_ * w2_ * w3_
+                common_F = np.zeros_like(psisq)
+                common_S = np.zeros_like(psisq)
+                common_F[mask] = 4.0 * (kT ** 2) / ((HBAR ** 2) * w_prod[mask])
+                common_S[mask] = 8.0 * (KB ** 2) * T_K / ((HBAR ** 2) * w_prod[mask])
+                common_Cv = common_S
+            else:
+                s1 = sigma_table[iq1][:, None, None]
+                s2 = sigma_table[iq2][None, :, None]
+                s3 = sigma_table[iq3][None, None, :]
+                sigma_combo = np.sqrt(s1 ** 2 + s2 ** 2 + s3 ** 2)
+                denom1 = w1_ + w2_ + w3_
+                Re1 = denom1 / (denom1 ** 2 + sigma_combo ** 2)
+                denom2 = w1_ + w2_ - w3_
+                Re2 = denom2 / (denom2 ** 2 + sigma_combo ** 2)
+
+                n1_ = n_tab[iq1][:, None, None]
+                n2_ = n_tab[iq2][None, :, None]
+                n3_ = n_tab[iq3][None, None, :]
+                dn1_ = dn_tab[iq1][:, None, None]
+                dn2_ = dn_tab[iq2][None, :, None]
+                dn3_ = dn_tab[iq3][None, None, :]
+                ddn1_ = ddn_tab[iq1][:, None, None]
+                ddn2_ = ddn_tab[iq2][None, :, None]
+                ddn3_ = ddn_tab[iq3][None, None, :]
+
+                f1 = (n1_ + 1.0) * (n2_ + n3_ + 1.0) + n2_ * n3_
+                f2 = n3_ * (n1_ + n2_ + 1.0) - n1_ * n2_
+
+                df1 = (dn1_ * (n2_ + n3_ + 1.0) + (n1_ + 1.0) * (dn2_ + dn3_)
+                       + dn2_ * n3_ + n2_ * dn3_)
+                df2 = (dn3_ * (n1_ + n2_ + 1.0) + dn1_ * (n3_ - n2_) + dn2_ * (n3_ - n1_))
+
+                ddf1 = (ddn1_ * (n2_ + n3_ + 1.0) + 2.0 * dn1_ * (dn2_ + dn3_)
+                        + (n1_ + 1.0) * (ddn2_ + ddn3_) + ddn2_ * n3_ + n2_ * ddn3_
+                        + 2.0 * dn2_ * dn3_)
+                ddf2 = (ddn3_ * (n1_ + n2_ + 1.0) + dn3_ * (dn1_ + dn2_)
+                        + ddn1_ * (n3_ - n2_) + dn1_ * (dn3_ - dn2_)
+                        + ddn2_ * (n3_ - n1_) + dn2_ * (dn3_ - dn1_))
+
+                common_F = (f1 * Re1 + 3.0 * f2 * Re2)
+                common_S = (df1 * Re1 + 3.0 * df2 * Re2)
+                common_Cv = (ddf1 * Re1 + 3.0 * ddf2 * Re2) * T_K
+
+            integrand_F = psisq * inv_w_prod * common_F / 48.0
+            integrand_S = psisq * inv_w_prod * common_S / 48.0
+            integrand_Cv = psisq * inv_w_prod * common_Cv / 48.0
+            F2 += w_q1 * integrand_F[mask].sum()
+            S2 += w_q1 * integrand_S[mask].sum()
+            Cv2 += w_q1 * integrand_Cv[mask].sum()
+        if log_every and (_i + 1) % log_every == 0:
+            logging.info(f"  q1={_i+1}/{n_q1}  elapsed={time.time()-t0:.1f}s")
+    return F2, S2, Cv2
+
+
+_ACCUMULATORS = {
+    'f1': _accumulate_f1_q1s,
+    'f2': _accumulate_f2_q1s,
+}
+
+
 def F1_vectorized(neighbors_pair, quartets, masses_kg, uc_positions, uc_cell,
-                  kmesh, T_K, use_q_symmetry=False, atoms=None, is_classic=False):
+                  kmesh, T_K, use_q_symmetry=False, atoms=None, is_classic=False,
+                  n_workers=1):
     """
     F1 / S1 / Cv1 / U1 quartic cumulant evaluator on a regular MP q-mesh.
 
@@ -159,12 +480,19 @@ def F1_vectorized(neighbors_pair, quartets, masses_kg, uc_positions, uc_cell,
     atoms : ASE Atoms (needed only when use_q_symmetry=True).
     is_classic : if True, use classical occupations ``2n+1 = 2 kT / (ħ ω)``
         (LDT ``quantum=false`` branch); else Bose–Einstein.
+    n_workers : int or None
+        Process-pool size for the outer q1 loop. ``1`` (default) is serial;
+        ``>1`` that many processes; ``None`` uses all CPUs. Flattened IFC
+        tables (QD) and other large arrays are attached via
+        ``multiprocessing.shared_memory`` so nested quartet lists are never
+        pickled into workers.
 
     Returns
     -------
     dict with keys ``F1``, ``S1``, ``Cv1``, ``U1`` (units eV/atom for F, U
     and kB/atom for S, Cv).
     """
+    _check_n_workers(n_workers)
     nx, ny, nz = kmesh
     n_uc = len(uc_positions)
     nb = 3 * n_uc
@@ -215,42 +543,29 @@ def F1_vectorized(neighbors_pair, quartets, masses_kg, uc_positions, uc_cell,
 
     n_q1 = len(q1_indices)
     logging.info(f"F1/S1/Cv1 double-q loop over {n_q1}x{nq}={n_q1*nq} (q1,q2) pairs"
-          + (" [q1 in IBZ]" if use_q_symmetry else ""))
+          + (" [q1 in IBZ]" if use_q_symmetry else "")
+          + (f" n_workers={n_workers}" if n_workers != 1 else ""))
     t2 = time.time()
-    F1_acc = 0.0
-    S1_acc = 0.0
-    Cv1_acc = 0.0
-    for _i, iq1 in enumerate(q1_indices):
-        q1c = cart[iq1]
-        M1 = M[iq1]
-        inv_w1 = inv_w[iq1]
-        two1 = two_np1[iq1]
-        dn1 = dn_tab[iq1]
-        ddn1 = ddn_tab[iq1]
-        ok1 = ok[iq1]
-        w1 = q1_weights[iq1]
-        for iq2 in range(nq):
-            q2c = cart[iq2]
-            A = build_psi4_realspace_v(QD, q1c, q2c)
-            T = np.einsum("kab,abcd->kcd", M1, A)
-            Psi4 = np.einsum("kcd,lcd->kl", T, M[iq2])
-            psi_re = np.real(Psi4)
-            mask = ok1[:, None] & ok[iq2][None, :]
-            inv_w_prod = inv_w1[:, None] * inv_w[iq2][None, :]
-
-            two2 = two_np1[iq2][None, :]
-            dn2 = dn_tab[iq2][None, :]
-            ddn2 = ddn_tab[iq2][None, :]
-            f_w = two1[:, None] * two2 * inv_w_prod
-            s_w = -(2.0 * dn1[:, None] * two2 + two1[:, None] * 2.0 * dn2) * inv_w_prod
-            cv_w = -(2.0 * ddn1[:, None] * two2 + 2.0 * ddn2 * two1[:, None]
-                     + 8.0 * dn1[:, None] * dn2) * T_K * inv_w_prod
-
-            F1_acc += w1 * (psi_re * f_w * mask).sum()
-            S1_acc += w1 * (psi_re * s_w * mask).sum()
-            Cv1_acc += w1 * (psi_re * cv_w * mask).sum()
-        if (_i + 1) % max(1, n_q1 // 20) == 0:
-            logging.info(f"  q1={_i+1}/{n_q1}  elapsed={time.time()-t2:.1f}s")
+    arrays = {
+        'cart': cart,
+        'M': M,
+        'inv_w': inv_w,
+        'two_np1': two_np1,
+        'dn_tab': dn_tab,
+        'ddn_tab': ddn_tab,
+        'ok': ok,
+        **_prefix_table('qd', QD, _QD_ARRAY_KEYS),
+    }
+    scalars = {
+        'qd_nb': int(QD['nb']),
+        'nq': int(nq),
+        'T_K': float(T_K),
+        'q1_weights': q1_weights,
+        'log_every': max(1, n_q1 // 20) if n_workers == 1 else None,
+    }
+    F1_acc, S1_acc, Cv1_acc = _run_parallel_q1(
+        'f1', q1_indices, n_workers, arrays, scalars,
+    )
     logging.info(f"F1 loop total {time.time()-t2:.1f}s")
 
     prefac = HBAR * HBAR / (32.0 * nq * nq * n_uc)
@@ -500,7 +815,7 @@ def smearingparameter(scaled_rec_basis, group_vel_alpha_nb, default_sigma_nb, sc
 
 def F2_vectorized(neighbors_pair, triplets, masses_kg, uc_positions, uc_cell,
                   kmesh, T_K, sigma_THz=None, use_q_symmetry=False, atoms=None,
-                  is_classic=False):
+                  is_classic=False, n_workers=1):
     """
     F2 / S2 / Cv2 / U2 cubic cumulant evaluator on a regular MP q-mesh.
 
@@ -516,8 +831,12 @@ def F2_vectorized(neighbors_pair, triplets, masses_kg, uc_positions, uc_cell,
     ``(kT)^2 / (ω1 ω2 ω3) / 12`` (no resonant principal-value denominators);
     quantum uses Bose occupations with adaptive/fixed σ smearing.
 
+    ``n_workers`` is as in :func:`F1_vectorized`: process-pool over q1,
+    with flattened IFC tables (TD) in shared memory.
+
     Returns a dict with keys ``F2``, ``S2``, ``Cv2``, ``U2``.
     """
+    _check_n_workers(n_workers)
     nx, ny, nz = kmesh
     nq = nx * ny * nz
     n_uc = len(uc_positions)
@@ -612,117 +931,40 @@ def F2_vectorized(neighbors_pair, triplets, masses_kg, uc_positions, uc_cell,
 
     n_q1 = len(q1_indices)
     logging.info(f"F2/S2/Cv2 double-q loop over {n_q1}x{nq}={n_q1*nq} (q1,q2) pairs"
-          + (" [q1 in IBZ]" if use_q_symmetry else ""))
+          + (" [q1 in IBZ]" if use_q_symmetry else "")
+          + (f" n_workers={n_workers}" if n_workers != 1 else ""))
     t2 = time.time()
-    F2 = 0.0
-    S2 = 0.0
-    Cv2 = 0.0
-
-    # Classical LDT weights: f0 = (kT)^2/(ω1 ω2 ω3)/12 replaces
-    # (f1 Re1 + 3 f2 Re2)/48, with ω in rad/s matching inv_w_prod; the
-    # outer ħ² prefactor converts to energy (same convention as classical F1).
-    # df0 = 2 f0 / T, ddf0 = df0 (Cv2 = S2).
     kT = KB * T_K
-
-    for _i, iq1 in enumerate(q1_indices):
-        i1, j1, k1 = frac_rounded[iq1]
-        e1 = egvs[iq1]
-        w1 = omegas[iq1]
-        ok1 = ok_tab[iq1]
-        w_q1 = q1_weights[iq1]
-        for iq2 in range(nq):
-            i2, j2, k2 = frac_rounded[iq2]
-            i3 = (-i1 - i2) % nx
-            j3 = (-j1 - j2) % ny
-            k3 = (-k1 - k2) % nz
-            iq3 = lookup[i3, j3, k3]
-            q2c = cart[iq2]
-            q3c = cart[iq3]
-
-            A = build_psi3_realspace(TD, q2c, q3c)
-
-            e2 = egvs[iq2]
-            e3 = egvs[iq3]
-            w2 = omegas[iq2]
-            w3 = omegas[iq3]
-            ok2 = ok_tab[iq2]
-            ok3 = ok_tab[iq3]
-
-            # Psi_3 via conjugated eigenvectors (LDT convention).
-            e1c = np.conj(e1)
-            e2c = np.conj(e2)
-            e3c = np.conj(e3)
-            T1 = np.einsum("abc,ak->kbc", A, e1c)
-            T2 = np.einsum("kbc,bl->klc", T1, e2c)
-            Psi3 = np.einsum("klc,cm->klm", T2, e3c)
-            psisq = np.abs(Psi3) ** 2
-
-            w1_ = w1[:, None, None]
-            w2_ = w2[None, :, None]
-            w3_ = w3[None, None, :]
-            mask = ok1[:, None, None] & ok2[None, :, None] & ok3[None, None, :]
-
-            inv_w_prod = np.zeros_like(psisq)
-            inv_w_prod[mask] = 1.0 / (w1_ * w2_ * w3_)[mask]
-
-            if is_classic:
-                # LDT classical: f0 = (kT)^2/(ω1 ω2 ω3)/12 replaces
-                # (f1 Re1 + 3 f2 Re2)/48.  Frequency unit matches inv_w_prod
-                # (rad/s); the outer ħ² prefactor supplies the energy conversion
-                # (same convention as classical F1 with 2n+1 = 2kT/(ħω)).
-                # common_F/48 = (kT)^2 / (ħ² ω1 ω2 ω3) / 12
-                w_prod = w1_ * w2_ * w3_
-                common_F = np.zeros_like(psisq)
-                common_S = np.zeros_like(psisq)
-                common_F[mask] = 4.0 * (kT ** 2) / ((HBAR ** 2) * w_prod[mask])
-                common_S[mask] = 8.0 * (KB ** 2) * T_K / ((HBAR ** 2) * w_prod[mask])
-                common_Cv = common_S
-            else:
-                s1 = sigma_table[iq1][:, None, None]
-                s2 = sigma_table[iq2][None, :, None]
-                s3 = sigma_table[iq3][None, None, :]
-                sigma_combo = np.sqrt(s1 ** 2 + s2 ** 2 + s3 ** 2)
-                denom1 = w1_ + w2_ + w3_
-                Re1 = denom1 / (denom1 ** 2 + sigma_combo ** 2)
-                denom2 = w1_ + w2_ - w3_
-                Re2 = denom2 / (denom2 ** 2 + sigma_combo ** 2)
-
-                n1_ = n_tab[iq1][:, None, None]
-                n2_ = n_tab[iq2][None, :, None]
-                n3_ = n_tab[iq3][None, None, :]
-                dn1_ = dn_tab[iq1][:, None, None]
-                dn2_ = dn_tab[iq2][None, :, None]
-                dn3_ = dn_tab[iq3][None, None, :]
-                ddn1_ = ddn_tab[iq1][:, None, None]
-                ddn2_ = ddn_tab[iq2][None, :, None]
-                ddn3_ = ddn_tab[iq3][None, None, :]
-
-                f1 = (n1_ + 1.0) * (n2_ + n3_ + 1.0) + n2_ * n3_
-                f2 = n3_ * (n1_ + n2_ + 1.0) - n1_ * n2_
-
-                df1 = (dn1_ * (n2_ + n3_ + 1.0) + (n1_ + 1.0) * (dn2_ + dn3_)
-                       + dn2_ * n3_ + n2_ * dn3_)
-                df2 = (dn3_ * (n1_ + n2_ + 1.0) + dn1_ * (n3_ - n2_) + dn2_ * (n3_ - n1_))
-
-                ddf1 = (ddn1_ * (n2_ + n3_ + 1.0) + 2.0 * dn1_ * (dn2_ + dn3_)
-                        + (n1_ + 1.0) * (ddn2_ + ddn3_) + ddn2_ * n3_ + n2_ * ddn3_
-                        + 2.0 * dn2_ * dn3_)
-                ddf2 = (ddn3_ * (n1_ + n2_ + 1.0) + dn3_ * (dn1_ + dn2_)
-                        + ddn1_ * (n3_ - n2_) + dn1_ * (dn3_ - dn2_)
-                        + ddn2_ * (n3_ - n1_) + dn2_ * (dn3_ - dn1_))
-
-                common_F = (f1 * Re1 + 3.0 * f2 * Re2)
-                common_S = (df1 * Re1 + 3.0 * df2 * Re2)
-                common_Cv = (ddf1 * Re1 + 3.0 * ddf2 * Re2) * T_K
-
-            integrand_F = psisq * inv_w_prod * common_F / 48.0
-            integrand_S = psisq * inv_w_prod * common_S / 48.0
-            integrand_Cv = psisq * inv_w_prod * common_Cv / 48.0
-            F2 += w_q1 * integrand_F[mask].sum()
-            S2 += w_q1 * integrand_S[mask].sum()
-            Cv2 += w_q1 * integrand_Cv[mask].sum()
-        if (_i + 1) % max(1, n_q1 // 10) == 0:
-            logging.info(f"  q1={_i+1}/{n_q1}  elapsed={time.time()-t2:.1f}s")
+    arrays = {
+        'cart': cart,
+        'egvs': egvs,
+        'omegas': omegas,
+        'frac_rounded': frac_rounded,
+        'lookup': lookup,
+        'ok_tab': ok_tab,
+        **_prefix_table('td', TD, _TD_ARRAY_KEYS),
+    }
+    if sigma_table is not None:
+        arrays['sigma_table'] = sigma_table
+    if n_tab is not None:
+        arrays['n_tab'] = n_tab
+        arrays['dn_tab'] = dn_tab
+        arrays['ddn_tab'] = ddn_tab
+    scalars = {
+        'td_nb': int(TD['nb']),
+        'nq': int(nq),
+        'nx': int(nx),
+        'ny': int(ny),
+        'nz': int(nz),
+        'T_K': float(T_K),
+        'is_classic': bool(is_classic),
+        'kT': float(kT),
+        'q1_weights': q1_weights,
+        'log_every': max(1, n_q1 // 10) if n_workers == 1 else None,
+    }
+    F2, S2, Cv2 = _run_parallel_q1(
+        'f2', q1_indices, n_workers, arrays, scalars,
+    )
     logging.info(f"F2 loop total {time.time()-t2:.1f}s")
 
     prefac = HBAR * HBAR / (nq * nq * n_uc)
@@ -950,7 +1192,7 @@ def _quartets_from_fc(fc):
 
 
 def F2_from_fc(fc, masses_amu, kmesh, T_K, sigma_THz=None,
-               use_q_symmetry=False, is_classic=False):
+               use_q_symmetry=False, is_classic=False, n_workers=1):
     """F2 cubic cumulant on a ``ForceConstants`` object (kaldo-native entry).
 
     Uses ``fc.atoms``, ``fc.second``, ``fc.third`` as the input data source
@@ -965,7 +1207,7 @@ def F2_from_fc(fc, masses_amu, kmesh, T_K, sigma_THz=None,
         ``ForceConstants.from_folder(..., format='tdep')``).
     masses_amu : (n_uc,) array
         Atomic masses in amu.
-    kmesh, T_K, sigma_THz, use_q_symmetry, is_classic :
+    kmesh, T_K, sigma_THz, use_q_symmetry, is_classic, n_workers :
         see :func:`F2_vectorized`.
 
     Returns
@@ -984,10 +1226,12 @@ def F2_from_fc(fc, masses_amu, kmesh, T_K, sigma_THz=None,
         use_q_symmetry=use_q_symmetry,
         atoms=fc.atoms,
         is_classic=is_classic,
+        n_workers=n_workers,
     )
 
 
-def F1_from_fc(fc, masses_amu, kmesh, T_K, use_q_symmetry=False, is_classic=False):
+def F1_from_fc(fc, masses_amu, kmesh, T_K, use_q_symmetry=False, is_classic=False,
+               n_workers=1):
     """F1 quartic cumulant on a ``ForceConstants`` object (kaldo-native entry).
 
     Requires ``fc.fourth`` loaded (``include_fourth=True`` in ``from_folder``).
@@ -1007,4 +1251,5 @@ def F1_from_fc(fc, masses_amu, kmesh, T_K, use_q_symmetry=False, is_classic=Fals
         use_q_symmetry=use_q_symmetry,
         atoms=fc.atoms if use_q_symmetry else None,
         is_classic=is_classic,
+        n_workers=n_workers,
     )

--- a/kaldo/cumulant/free_energy.py
+++ b/kaldo/cumulant/free_energy.py
@@ -135,6 +135,48 @@ def build_psi4_realspace_v(QD, q1_cart, q2_cart):
     return A
 
 
+def _quartet_mode_blocks(Mq, atom_left, atom_right):
+    """Gather per-quartet 3x3 blocks from mode outer products."""
+    xyz = np.arange(3)
+    left = 3 * atom_left[:, None] + xyz[None, :]
+    right = 3 * atom_right[:, None] + xyz[None, :]
+    blocks = Mq[:, left[:, :, None], right[:, None, :]]
+    return np.moveaxis(blocks, 1, 0)
+
+
+def _quartet_mode_blocks_batch(Mq, atom_left, atom_right):
+    """Gather per-quartet 3x3 blocks for a batch of q-points."""
+    xyz = np.arange(3)
+    left = 3 * atom_left[:, None] + xyz[None, :]
+    right = 3 * atom_right[:, None] + xyz[None, :]
+    blocks = Mq[:, :, left[:, :, None], right[:, None, :]]
+    return np.moveaxis(blocks, 2, 1)
+
+
+def _prepare_psi4_q1(QD, M1, q1_cart):
+    """Contract the q1 mode blocks with IFC4 once for an outer-q1 task."""
+    M1_blocks = _quartet_mode_blocks(M1, QD["a1"], QD["a2"])
+    left = np.einsum("nkab,nabcd->nkcd", M1_blocks, QD["ifc"], optimize=True)
+    phase_q1 = np.exp(-1j * (QD["lv2c"] @ q1_cart))
+    return left * phase_q1[:, None, None, None]
+
+
+def _build_psi4_modes_quartet(QD, left_q1, M2, q2_cart):
+    """Build mode-space Psi4 directly in quartet space, without scattering."""
+    M2_blocks = _quartet_mode_blocks(M2, QD["a3"], QD["a4"])
+    phase_q2 = np.exp(1j * ((QD["lv3c"] - QD["lv4c"]) @ q2_cart))
+    per_quartet = np.einsum("nkcd,nlcd->nkl", left_q1, M2_blocks, optimize=True)
+    return np.einsum("n,nkl->kl", phase_q2, per_quartet, optimize=True)
+
+
+def _build_psi4_modes_quartet_batch(QD, left_q1, M2, q2_cart):
+    """Build mode-space Psi4 for a batch of q2 points."""
+    M2_blocks = _quartet_mode_blocks_batch(M2, QD["a3"], QD["a4"])
+    phase_q2 = np.exp(1j * (q2_cart @ (QD["lv3c"] - QD["lv4c"]).T))
+    per_quartet = np.einsum("nkcd,bnlcd->bnkl", left_q1, M2_blocks, optimize=True)
+    return np.einsum("bn,bnkl->bkl", phase_q2, per_quartet, optimize=True)
+
+
 # ---------------------------------------------------------------------------
 # Process-pool q1 reduction: SharedMemory for flattened IFCs (QD/TD) and
 # other large read-only arrays. Nested quartet/triplet lists never leave
@@ -143,6 +185,8 @@ def build_psi4_realspace_v(QD, q1_cart, q2_cart):
 
 _QD_ARRAY_KEYS = ('a1', 'a2', 'a3', 'a4', 'lv2c', 'lv3c', 'lv4c', 'ifc')
 _TD_ARRAY_KEYS = ('a1', 'a2', 'a3', 'lv2c', 'lv3c', 'ifc')
+_F1_Q2_BATCH_SIZE = 4
+_F2_Q2_BATCH_SIZE = 8
 
 # Filled by _init_q1_worker in process-pool children; unused on the serial path.
 _WORKER_Q1 = None
@@ -236,7 +280,7 @@ def _q1_chunk_worker(iq1_list):
 
 
 def _run_parallel_q1(accumulate_key, q1_indices, n_workers, arrays, scalars):
-    """Map q1 chunks onto processes; reduce (F, S, Cv) with +."""
+    """Map individual q1 points onto processes; reduce (F, S, Cv) with +."""
     from kaldo.parallel import get_executor, is_parallel
 
     iq1s = [int(i) for i in q1_indices]
@@ -244,29 +288,33 @@ def _run_parallel_q1(accumulate_key, q1_indices, n_workers, arrays, scalars):
         return _ACCUMULATORS[accumulate_key](iq1s, arrays, scalars)
 
     n_cpu = n_workers if n_workers is not None else (os.cpu_count() or 1)
-    n_chunks = max(1, min(int(n_cpu), len(iq1s)))
-    chunks = [
-        c.tolist() for c in np.array_split(np.asarray(iq1s, dtype=int), n_chunks)
-        if c.size
-    ]
+    n_processes = max(1, min(int(n_cpu), len(iq1s)))
     payload = dict(scalars)
     payload['_accumulate'] = accumulate_key
     store = _SharedArrayStore(arrays)
     F = S = Cv = 0.0
+    n_q1 = len(iq1s)
+    report_every = max(1, n_q1 // 20)
+    t0 = time.time()
     try:
         with get_executor(
             backend='process',
-            n_workers=len(chunks),
+            n_workers=n_processes,
             initializer=_init_q1_worker,
             initargs=(1, store.spec, payload),
         ) as executor:
-            futures = [executor.submit(_q1_chunk_worker, chunk) for chunk in chunks]
+            futures = [executor.submit(_q1_chunk_worker, [iq1]) for iq1 in iq1s]
             for i, fut in enumerate(as_completed(futures), 1):
                 f, s, cv = fut.result()
                 F += f
                 S += s
                 Cv += cv
-                logging.info(f"  q1-chunk {i}/{len(chunks)}")
+                if i == 1 or i == n_q1 or i % report_every == 0:
+                    elapsed = time.time() - t0
+                    logging.info(
+                        f"  q1={i}/{n_q1} ({100.0*i/n_q1:.0f}%)  "
+                        f"elapsed={elapsed:.1f}s"
+                    )
     finally:
         store.close_and_unlink()
     return F, S, Cv
@@ -293,28 +341,32 @@ def _accumulate_f1_q1s(iq1_list, arrays, scalars):
     for _i, iq1 in enumerate(iq1_list):
         q1c = cart[iq1]
         M1 = M[iq1]
+        psi4_left = _prepare_psi4_q1(QD, M1, q1c)
         inv_w1 = inv_w[iq1]
         two1 = two_np1[iq1]
         dn1 = dn_tab[iq1]
         ddn1 = ddn_tab[iq1]
         ok1 = ok[iq1]
         w1 = q1_weights[iq1]
-        for iq2 in range(nq):
-            q2c = cart[iq2]
-            A = build_psi4_realspace_v(QD, q1c, q2c)
-            T = np.einsum("kab,abcd->kcd", M1, A)
-            Psi4 = np.einsum("kcd,lcd->kl", T, M[iq2])
+        for iq2_start in range(0, nq, _F1_Q2_BATCH_SIZE):
+            iq2_stop = min(iq2_start + _F1_Q2_BATCH_SIZE, nq)
+            q2_slice = slice(iq2_start, iq2_stop)
+            Psi4 = _build_psi4_modes_quartet_batch(
+                QD, psi4_left, M[q2_slice], cart[q2_slice],
+            )
             psi_re = np.real(Psi4)
-            mask = ok1[:, None] & ok[iq2][None, :]
-            inv_w_prod = inv_w1[:, None] * inv_w[iq2][None, :]
+            mask = ok1[None, :, None] & ok[q2_slice][:, None, :]
+            inv_w_prod = inv_w1[None, :, None] * inv_w[q2_slice][:, None, :]
 
-            two2 = two_np1[iq2][None, :]
-            dn2 = dn_tab[iq2][None, :]
-            ddn2 = ddn_tab[iq2][None, :]
-            f_w = two1[:, None] * two2 * inv_w_prod
-            s_w = -(2.0 * dn1[:, None] * two2 + two1[:, None] * 2.0 * dn2) * inv_w_prod
-            cv_w = -(2.0 * ddn1[:, None] * two2 + 2.0 * ddn2 * two1[:, None]
-                     + 8.0 * dn1[:, None] * dn2) * T_K * inv_w_prod
+            two2 = two_np1[q2_slice][:, None, :]
+            dn2 = dn_tab[q2_slice][:, None, :]
+            ddn2 = ddn_tab[q2_slice][:, None, :]
+            f_w = two1[None, :, None] * two2 * inv_w_prod
+            s_w = -(2.0 * dn1[None, :, None] * two2
+                    + two1[None, :, None] * 2.0 * dn2) * inv_w_prod
+            cv_w = -(2.0 * ddn1[None, :, None] * two2
+                     + 2.0 * ddn2 * two1[None, :, None]
+                     + 8.0 * dn1[None, :, None] * dn2) * T_K * inv_w_prod
 
             F1_acc += w1 * (psi_re * f_w * mask).sum()
             S1_acc += w1 * (psi_re * s_w * mask).sum()
@@ -353,39 +405,31 @@ def _accumulate_f2_q1s(iq1_list, arrays, scalars):
     for _i, iq1 in enumerate(iq1_list):
         i1, j1, k1 = frac_rounded[iq1]
         e1 = egvs[iq1]
+        psi3_left = _prepare_psi3_q1(TD, e1)
         w1 = omegas[iq1]
         ok1 = ok_tab[iq1]
         w_q1 = q1_weights[iq1]
-        for iq2 in range(nq):
-            i2, j2, k2 = frac_rounded[iq2]
-            i3 = (-i1 - i2) % nx
-            j3 = (-j1 - j2) % ny
-            k3 = (-k1 - k2) % nz
+        for iq2_start in range(0, nq, _F2_Q2_BATCH_SIZE):
+            iq2_stop = min(iq2_start + _F2_Q2_BATCH_SIZE, nq)
+            q2_slice = slice(iq2_start, iq2_stop)
+            q2_grid = frac_rounded[q2_slice]
+            i3 = (-i1 - q2_grid[:, 0]) % nx
+            j3 = (-j1 - q2_grid[:, 1]) % ny
+            k3 = (-k1 - q2_grid[:, 2]) % nz
             iq3 = lookup[i3, j3, k3]
-            q2c = cart[iq2]
-            q3c = cart[iq3]
 
-            A = build_psi3_realspace(TD, q2c, q3c)
-
-            e2 = egvs[iq2]
-            e3 = egvs[iq3]
-            w2 = omegas[iq2]
-            w3 = omegas[iq3]
-            ok2 = ok_tab[iq2]
-            ok3 = ok_tab[iq3]
-
-            e1c = np.conj(e1)
-            e2c = np.conj(e2)
-            e3c = np.conj(e3)
-            T1 = np.einsum("abc,ak->kbc", A, e1c)
-            T2 = np.einsum("kbc,bl->klc", T1, e2c)
-            Psi3 = np.einsum("klc,cm->klm", T2, e3c)
+            Psi3 = _build_psi3_modes_triplet_batch(
+                TD, psi3_left, egvs[q2_slice], egvs[iq3],
+                cart[q2_slice], cart[iq3],
+            )
             psisq = np.abs(Psi3) ** 2
 
-            w1_ = w1[:, None, None]
-            w2_ = w2[None, :, None]
-            w3_ = w3[None, None, :]
-            mask = ok1[:, None, None] & ok2[None, :, None] & ok3[None, None, :]
+            w1_ = w1[None, :, None, None]
+            w2_ = omegas[q2_slice][:, None, :, None]
+            w3_ = omegas[iq3][:, None, None, :]
+            mask = (ok1[None, :, None, None]
+                    & ok_tab[q2_slice][:, None, :, None]
+                    & ok_tab[iq3][:, None, None, :])
 
             inv_w_prod = np.zeros_like(psisq)
             inv_w_prod[mask] = 1.0 / (w1_ * w2_ * w3_)[mask]
@@ -398,24 +442,24 @@ def _accumulate_f2_q1s(iq1_list, arrays, scalars):
                 common_S[mask] = 8.0 * (KB ** 2) * T_K / ((HBAR ** 2) * w_prod[mask])
                 common_Cv = common_S
             else:
-                s1 = sigma_table[iq1][:, None, None]
-                s2 = sigma_table[iq2][None, :, None]
-                s3 = sigma_table[iq3][None, None, :]
+                s1 = sigma_table[iq1][None, :, None, None]
+                s2 = sigma_table[q2_slice][:, None, :, None]
+                s3 = sigma_table[iq3][:, None, None, :]
                 sigma_combo = np.sqrt(s1 ** 2 + s2 ** 2 + s3 ** 2)
                 denom1 = w1_ + w2_ + w3_
                 Re1 = denom1 / (denom1 ** 2 + sigma_combo ** 2)
                 denom2 = w1_ + w2_ - w3_
                 Re2 = denom2 / (denom2 ** 2 + sigma_combo ** 2)
 
-                n1_ = n_tab[iq1][:, None, None]
-                n2_ = n_tab[iq2][None, :, None]
-                n3_ = n_tab[iq3][None, None, :]
-                dn1_ = dn_tab[iq1][:, None, None]
-                dn2_ = dn_tab[iq2][None, :, None]
-                dn3_ = dn_tab[iq3][None, None, :]
-                ddn1_ = ddn_tab[iq1][:, None, None]
-                ddn2_ = ddn_tab[iq2][None, :, None]
-                ddn3_ = ddn_tab[iq3][None, None, :]
+                n1_ = n_tab[iq1][None, :, None, None]
+                n2_ = n_tab[q2_slice][:, None, :, None]
+                n3_ = n_tab[iq3][:, None, None, :]
+                dn1_ = dn_tab[iq1][None, :, None, None]
+                dn2_ = dn_tab[q2_slice][:, None, :, None]
+                dn3_ = dn_tab[iq3][:, None, None, :]
+                ddn1_ = ddn_tab[iq1][None, :, None, None]
+                ddn2_ = ddn_tab[q2_slice][:, None, :, None]
+                ddn3_ = ddn_tab[iq3][:, None, None, :]
 
                 f1 = (n1_ + 1.0) * (n2_ + n3_ + 1.0) + n2_ * n3_
                 f2 = n3_ * (n1_ + n2_ + 1.0) - n1_ * n2_
@@ -631,6 +675,35 @@ def build_psi3_realspace(TD, q2_cart, q3_cart):
     a1_idx, a2_idx, a3_idx = np.broadcast_arrays(a1_idx, a2_idx, a3_idx)
     np.add.at(A, (a1_idx, a2_idx, a3_idx), scaled)
     return A
+
+
+def _triplet_mode_vectors(egv, atoms):
+    """Gather Cartesian mode vectors for each triplet atom."""
+    xyz = np.arange(3)
+    indices = 3 * atoms[:, None] + xyz[None, :]
+    return np.moveaxis(egv[indices, :], 2, 1)
+
+
+def _triplet_mode_vectors_batch(egv, atoms):
+    """Gather Cartesian mode vectors for a batch of q-points."""
+    xyz = np.arange(3)
+    indices = 3 * atoms[:, None] + xyz[None, :]
+    return np.moveaxis(egv[:, indices, :], 3, 2)
+
+
+def _prepare_psi3_q1(TD, e1):
+    """Contract q1 mode vectors with IFC3 once for an outer-q1 task."""
+    e1_vectors = _triplet_mode_vectors(np.conj(e1), TD["a1"])
+    return np.einsum("nka,nabc->nkbc", e1_vectors, TD["ifc"], optimize=True)
+
+
+def _build_psi3_modes_triplet_batch(TD, left_q1, e2, e3, q2_cart, q3_cart):
+    """Build mode-space Psi3 for a batch without a real-space scatter."""
+    e2_vectors = _triplet_mode_vectors_batch(np.conj(e2), TD["a2"])
+    e3_vectors = _triplet_mode_vectors_batch(np.conj(e3), TD["a3"])
+    phase = np.exp(-1j * (q2_cart @ TD["lv2c"].T + q3_cart @ TD["lv3c"].T))
+    middle = np.einsum("nkbc,qnlb->qnklc", left_q1, e2_vectors, optimize=True)
+    return np.einsum("qnklc,qnmc,qn->qklm", middle, e3_vectors, phase, optimize=True)
 
 
 def planck_and_derivs(omega, T_K, is_classic=False):

--- a/kaldo/cumulant/thermodynamics.py
+++ b/kaldo/cumulant/thermodynamics.py
@@ -15,6 +15,7 @@ matches to 1.7e-7 eV/atom < Ethan's own SE).
 """
 from __future__ import annotations
 
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -73,13 +74,55 @@ class CumulantResult:
     V2_tilde: np.ndarray
 
 
-def _harmonic_thermo(forceconstants, kmesh, T_K, is_classic=False):
+def _parallel_phonon_frequencies(ph, n_workers):
+    """``HarmonicWithQ`` frequencies on ``ph``'s mesh, sharded over processes."""
+    from concurrent.futures import as_completed
+
+    from kaldo.parallel import get_executor
+
+    from ._harmonic_worker import freq_q_chunk, init_freq_worker
+
+    q_points = np.asarray(ph._reciprocal_grid.unitary_grid(is_wrapping=False))
+    n_q = int(q_points.shape[0])
+    n_cpu = n_workers if n_workers is not None else (os.cpu_count() or 1)
+    n_cpu = max(1, min(int(n_cpu), n_q))
+    chunks = [c for c in np.array_split(q_points, n_cpu) if c.size]
+    second = ph.forceconstants.second
+    # Materialize IFC2 as numpy so spawn pickles arrays, not TF tensors.
+    second._dynmat = np.asarray(second.dynmat)
+    hwq_kwargs = dict(
+        distance_threshold=ph.forceconstants.distance_threshold,
+        folder=ph.folder,
+        storage="memory",
+        is_nw=ph.is_nw,
+        is_unfolding=ph.is_unfolding,
+        is_amorphous=ph._is_amorphous,
+    )
+    parts = [None] * len(chunks)
+    with get_executor(
+        backend="process",
+        n_workers=len(chunks),
+        initializer=init_freq_worker,
+        initargs=(1, second, hwq_kwargs),
+    ) as executor:
+        futures = {executor.submit(freq_q_chunk, chunk): i
+                   for i, chunk in enumerate(chunks)}
+        for fut in as_completed(futures):
+            parts[futures[fut]] = fut.result()
+    return np.concatenate(parts, axis=0)
+
+
+def _harmonic_thermo(forceconstants, kmesh, T_K, is_classic=False, n_workers=1):
     """Phase-1 F_H/U_H/S_H/Cv_H from ``Phonons`` frequencies.
 
     Uses kaldo's ``HarmonicWithQ`` dynamical matrix (including the
     per-pair Fourier phases on non-diagonal TDEP supercells from PR #301),
     then the cumulant classical/quantum closed-form sums.
+    ``n_workers=1`` is the in-process ``Phonons.frequency`` loop; ``>1``
+    shards that q-loop across processes (same dynmat, same ``n_workers``
+    flag as F1/F2 and Phase 5).
     """
+    from kaldo.parallel import is_parallel
     from kaldo.phonons import Phonons
 
     ph = Phonons(
@@ -89,7 +132,10 @@ def _harmonic_thermo(forceconstants, kmesh, T_K, is_classic=False):
         is_classic=is_classic,
         storage="memory",
     )
-    freqs = np.asarray(ph.frequency)  # (n_q, n_modes) THz
+    if is_parallel(n_workers):
+        freqs = _parallel_phonon_frequencies(ph, n_workers)
+    else:
+        freqs = np.asarray(ph.frequency)  # (n_q, n_modes) THz
     n_q, n_modes = freqs.shape
     n_uc = n_modes // 3
     F, U, S, Cv = harmonic_thermo(
@@ -113,6 +159,7 @@ def cumulant_thermo(
     lammps_kwargs: dict | None = None,
     calculator=None,
     verbose: bool = True,
+    n_workers: int | None = 1,
 ) -> CumulantResult:
     """
     Full cumulant thermodynamics on TDEP IFC inputs.
@@ -170,6 +217,16 @@ def cumulant_thermo(
         ``calculator`` must be given.
     verbose : bool
         If True, print progress messages. Default is True.
+    n_workers : int or None
+        Process-pool size for Phase-1 frequencies (full harmonic q-mesh),
+        analytic F1/F2 (outer IBZ q1 loop), and Phase-5 sampling (one
+        LAMMPS / calculator per process). ``1`` (default) is serial; ``>1``
+        that many processes; ``None`` uses all CPUs. This is the only
+        parallelism control for ``cumulant_thermo``; V2/V3/V4 contractions
+        stay in-process. See :func:`kaldo.cumulant.free_energy.F1_vectorized`.
+        When ``n_workers > 1`` and ``calculator=`` is used, pass a picklable
+        instance or a no-arg factory (same rule as finite-difference
+        ``n_workers``).
 
     Returns
     -------
@@ -177,6 +234,10 @@ def cumulant_thermo(
     """
 
     from ase import Atoms
+    from kaldo.cumulant.free_energy import _check_n_workers
+    from kaldo.parallel import is_parallel, get_executor, validate_parallel_calculator
+
+    _check_n_workers(n_workers)
 
     if (lammps_cmds is None) == (calculator is None):
         raise ValueError(
@@ -228,6 +289,7 @@ def cumulant_thermo(
     t0 = time.time()
     harm = _harmonic_thermo(
         forceconstants, tuple(harmonic_mesh), temperature, is_classic=is_classic,
+        n_workers=n_workers,
     )
     if verbose:
         logging.info(f"  F_H={harm['F_H']:+.4e}  U_H={harm['U_H']:+.4e}  "
@@ -243,6 +305,7 @@ def cumulant_thermo(
         forceconstants, masses_amu=masses_amu_uc,
         kmesh=tuple(free_energy_mesh), T_K=temperature,
         use_q_symmetry=use_q_symmetry, is_classic=is_classic,
+        n_workers=n_workers,
     )
     if verbose:
         logging.info(f"  F1={res1['F1']:+.4e}  U1={res1['U1']:+.4e}  "
@@ -258,6 +321,7 @@ def cumulant_thermo(
         forceconstants, masses_amu=masses_amu_uc,
         kmesh=tuple(free_energy_mesh), T_K=temperature, sigma_THz=None,
         use_q_symmetry=use_q_symmetry, is_classic=is_classic,
+        n_workers=n_workers,
     )
     if verbose:
         logging.info(f"  F2={res2['F2']:+.4e}  U2={res2['U2']:+.4e}  "
@@ -310,22 +374,26 @@ def cumulant_thermo(
     if verbose:
         logging.info(f"Phase 5: Built sampler ...")
 
-    contractors = SCContractors.from_tdep_folder(tdep_folder, include_fourth=True)
-
-    if verbose:
-        logging.info(f"Phase 5: Build contractors ...")
+    # Serial keeps contractors in-process. Parallel workers rebuild from
+    # the TDEP folder so we do not pickle phi4.
+    contractors = None
+    if not is_parallel(n_workers):
+        contractors = SCContractors.from_tdep_folder(tdep_folder, include_fourth=True)
+        if verbose:
+            logging.info("Phase 5: Build contractors ...")
 
     sc_cell_A = np.asarray(sc.get_cell())
     sc_pos_eq_A = np.asarray(sc.get_positions())
 
-    at = Atoms(species_sc, positions=sc_pos_eq_A, cell=sc_cell_A, pbc=True)
+    if calculator is not None and is_parallel(n_workers):
+        validate_parallel_calculator(calculator, "cumulant_thermo")
+
+    from ._phase5_worker import run_phase5_loop, run_phase5_chunk, _lammps_log_path
+
     if calculator is not None:
         if verbose:
             logging.info(f"Phase 5: Using ASE calculator {type(calculator).__name__} ...")
-        at.calc = calculator
     else:
-        from ase.calculators.lammpslib import LAMMPSlib
-
         # Build mappings for the LAMMPS calculator
         _, unique_species_idx = np.unique(species_uc, return_index=True)
         if "atom_types" not in lammps_kwargs:
@@ -333,42 +401,80 @@ def cumulant_thermo(
         if "atom_type_masses" not in lammps_kwargs:
             lammps_kwargs["atom_type_masses"] = {species_uc[idx]: masses_amu_uc[idx]
                                                  for i, idx in enumerate(unique_species_idx)}
-
         if verbose:
             logging.info("Phase 5: Building LAMMPS calculator ...")
             logging.info(f"  LAMMPS atom_types: {lammps_kwargs['atom_types']}")
             logging.info(f"  LAMMPS atom_type_masses: {lammps_kwargs['atom_type_masses']}")
 
-        at.calc = LAMMPSlib(
-            lmpcmds=list(lammps_cmds),
-            keep_alive=True,
-            log_file="/tmp/cumulant_thermo_lammps.log",
-            **lammps_kwargs
-        )
-    # Every sampled configuration shares topology (same atoms, same box; only
-    # positions move), so keep one LAMMPS instance alive and, per config,
-    # scatter coordinates + `run 1 pre no` (LDT pattern: recompute pe without
-    # rebuilding neighbors; large skin keeps the list valid). The first
-    # energy() call does the full ASE setup. See BatchEnergyEvaluator.
-    from ._energy_evaluator import BatchEnergyEvaluator
-    energy_eval = BatchEnergyEvaluator(at, sc_pos_eq_A)
-
-    V = np.zeros(nconf)
-    V2 = np.zeros(nconf)
-    V3 = np.zeros(nconf)
-    V4 = np.zeros(nconf)
-    V2_tilde = np.zeros(nconf)
-    dV2_tilde_dT = np.zeros(nconf)
     t0 = time.time()
-    for n in range(nconf):
-        u, z = sampler.draw_with_z()
-        V[n] = energy_eval.energy(u)
-        V2[n] = contractors.V2(u)
-        V3[n] = contractors.V3(u)
-        V4[n] = contractors.V4(u)
-        V2_tilde[n], dV2_tilde_dT[n] = sampler.V2_tilde_and_dT_from_z(z)
-        if verbose and (n + 1) % max(1, nconf // 10) == 0:
-            logging.info(f"  n={n+1}/{nconf}  ({time.time()-t0:.1f}s)")
+    if not is_parallel(n_workers):
+        at = Atoms(species_sc, positions=sc_pos_eq_A, cell=sc_cell_A, pbc=True)
+        if calculator is not None:
+            at.calc = calculator
+        else:
+            from ase.calculators.lammpslib import LAMMPSlib
+            at.calc = LAMMPSlib(
+                lmpcmds=list(lammps_cmds),
+                keep_alive=True,
+                log_file=_lammps_log_path(),
+                **lammps_kwargs
+            )
+        # Every sampled configuration shares topology (same atoms, same box; only
+        # positions move), so keep one LAMMPS instance alive and, per config,
+        # scatter coordinates + `run 1 pre no` (LDT pattern: recompute pe without
+        # rebuilding neighbors; large skin keeps the list valid). The first
+        # energy() call does the full ASE setup. See BatchEnergyEvaluator.
+        from ._energy_evaluator import BatchEnergyEvaluator
+        energy_eval = BatchEnergyEvaluator(at, sc_pos_eq_A)
+        V, V2, V3, V4, V2_tilde, dV2_tilde_dT = run_phase5_loop(
+            nconf, sampler, contractors, energy_eval,
+            verbose=verbose, logger=logging,
+        )
+    else:
+        n_cpu = n_workers if n_workers is not None else (os.cpu_count() or 1)
+        n_cpu = max(1, min(int(n_cpu), nconf))
+        counts = [len(c) for c in np.array_split(np.arange(nconf), n_cpu)]
+        counts = [c for c in counts if c > 0]
+        if verbose:
+            logging.info(f"Phase 5: starting {len(counts)} processes "
+                         f"({nconf} configs, one LAMMPS each) ...")
+        base = dict(
+            sampler=sampler,
+            tdep_folder=str(Path(tdep_folder)),
+            include_fourth=True,
+            species=list(species_sc),
+            eq=np.asarray(sc_pos_eq_A),
+            cell=np.asarray(sc_cell_A),
+            lammps_cmds=lammps_cmds,
+            lammps_kwargs=lammps_kwargs,
+            calculator=calculator,
+            seed=seed,
+        )
+        specs = []
+        for i, n_local in enumerate(counts):
+            spec = dict(base)
+            spec["n_local"] = int(n_local)
+            spec["worker_id"] = i
+            specs.append(spec)
+        from concurrent.futures import as_completed
+        parts = [None] * len(specs)
+        with get_executor(backend="process", n_workers=len(specs)) as executor:
+            futures = {executor.submit(run_phase5_chunk, spec): i
+                       for i, spec in enumerate(specs)}
+            n_done = 0
+            for fut in as_completed(futures):
+                i = futures[fut]
+                parts[i] = fut.result()
+                n_done += 1
+                if verbose:
+                    logging.info(f"  Phase 5 finished {n_done}/{len(specs)} chunks "
+                                 f"({time.time()-t0:.1f}s)")
+        V = np.concatenate([p[0] for p in parts])
+        V2 = np.concatenate([p[1] for p in parts])
+        V3 = np.concatenate([p[2] for p in parts])
+        V4 = np.concatenate([p[3] for p in parts])
+        V2_tilde = np.concatenate([p[4] for p in parts])
+        dV2_tilde_dT = np.concatenate([p[5] for p in parts])
 
     # Classical: V_ref = V2, dV_ref_dT ≡ 0.
     # Quantum: V_ref = V2_tilde (Bose-reweighted), with explicit ∂Ṽ₂/∂T.
@@ -426,11 +532,11 @@ def print_thermo_table(result: CumulantResult) -> None:
         ("Cv", "kB/atom", result.Cv_H, result.Cv_0, result.Cv_1, result.Cv_2,
          result.Cv_total, result.Cv_total_SE),
     ]
+    col = 14
     for name, unit, H, zeroth, a1, a2, tot, se in rows:
         print(f"\n# {name} [{unit}]")
-        print(f"       {name}_H          {name}_0            "
-              f"{name}_1            {name}_2            {name}_total")
-        print(f"  {H:+.7f}      {zeroth:+.7f}      "
-              f"{a1:+.7f}      {a2:+.7f}      {tot:+.7f}")
-        print(f"  {'0':>14}      {se:.7f}      "
-              f"{'0':>14}      {'0':>14}      {se:.7f}")
+        labels = (f"{name}_H", f"{name}_0", f"{name}_1", f"{name}_2",
+                  f"{name}_total")
+        print("".join(f"{lab:>{col}}" for lab in labels))
+        print("".join(f"{v:+{col}.7f}" for v in (H, zeroth, a1, a2, tot)))
+        print("".join(f"{v:+{col}.7f}" for v in (0.0, se, 0.0, 0.0, se)))

--- a/kaldo/cumulant/thermodynamics.py
+++ b/kaldo/cumulant/thermodynamics.py
@@ -438,6 +438,13 @@ def cumulant_thermo(
         if verbose:
             logging.info(f"Phase 5: starting {len(counts)} processes "
                          f"({nconf} configs, one LAMMPS each) ...")
+        from multiprocessing import shared_memory
+        progress_shape = (len(counts), 8)  # one cache line per worker
+        progress_shm = shared_memory.SharedMemory(
+            create=True, size=int(np.prod(progress_shape)) * np.dtype(np.int64).itemsize,
+        )
+        progress = np.ndarray(progress_shape, dtype=np.int64, buffer=progress_shm.buf)
+        progress.fill(0)
         base = dict(
             sampler=sampler,
             tdep_folder=str(Path(tdep_folder)),
@@ -449,6 +456,8 @@ def cumulant_thermo(
             lammps_kwargs=lammps_kwargs,
             calculator=calculator,
             seed=seed,
+            progress_shm_name=progress_shm.name,
+            progress_shape=progress_shape,
         )
         specs = []
         for i, n_local in enumerate(counts):
@@ -456,19 +465,35 @@ def cumulant_thermo(
             spec["n_local"] = int(n_local)
             spec["worker_id"] = i
             specs.append(spec)
-        from concurrent.futures import as_completed
+        from concurrent.futures import FIRST_COMPLETED, wait
         parts = [None] * len(specs)
-        with get_executor(backend="process", n_workers=len(specs)) as executor:
-            futures = {executor.submit(run_phase5_chunk, spec): i
-                       for i, spec in enumerate(specs)}
-            n_done = 0
-            for fut in as_completed(futures):
-                i = futures[fut]
-                parts[i] = fut.result()
-                n_done += 1
-                if verbose:
-                    logging.info(f"  Phase 5 finished {n_done}/{len(specs)} chunks "
-                                 f"({time.time()-t0:.1f}s)")
+        try:
+            with get_executor(backend="process", n_workers=len(specs)) as executor:
+                futures = {executor.submit(run_phase5_chunk, spec): i
+                           for i, spec in enumerate(specs)}
+                pending = set(futures)
+                report_every = max(1, (nconf + 49) // 50)
+                next_report = report_every
+                while pending:
+                    done, pending = wait(
+                        pending, timeout=1.0, return_when=FIRST_COMPLETED,
+                    )
+                    for fut in done:
+                        i = futures[fut]
+                        parts[i] = fut.result()
+                    elapsed = time.time() - t0
+                    completed = int(progress[:, 0].sum())
+                    if verbose and (completed >= next_report or not pending):
+                        logging.info(
+                            f"  Phase 5: {completed}/{nconf} "
+                            f"({100.0*completed/nconf:.0f}%)  "
+                            f"elapsed={elapsed:.1f}s"
+                        )
+                        while next_report <= completed:
+                            next_report += report_every
+        finally:
+            progress_shm.close()
+            progress_shm.unlink()
         V = np.concatenate([p[0] for p in parts])
         V2 = np.concatenate([p[1] for p in parts])
         V3 = np.concatenate([p[2] for p in parts])

--- a/kaldo/tests/test_cumulant_v2tilde_and_table.py
+++ b/kaldo/tests/test_cumulant_v2tilde_and_table.py
@@ -99,3 +99,9 @@ def test_print_thermo_table_runs(capsys):
     assert "F_0" in out and "F_total" in out
     assert "F_offset" not in out
     assert "+0.0698000" in out  # F_total value rendered
+    # Header + value + SE rows of each block share a fixed width.
+    lines = out.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith("# F "):
+            header, values, se = lines[i + 1], lines[i + 2], lines[i + 3]
+            assert len(header) == len(values) == len(se)

--- a/kaldo/tests/test_parallel_cumulant.py
+++ b/kaldo/tests/test_parallel_cumulant.py
@@ -1,0 +1,94 @@
+"""Parallel F1/F2 over IBZ q1 vs the serial path.
+
+n_workers=2 must match n_workers=1. Flattened IFC tables are attached
+via SharedMemory (not pickled nested quartet/triplet lists).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from kaldo.forceconstants import ForceConstants
+from kaldo.cumulant import F1_from_fc, F2_from_fc
+from kaldo.cumulant.thermodynamics import _harmonic_thermo
+
+NE_IFC = Path(__file__).parent / "cumulant_fixtures" / "LJ" / "Neon_14K_4UC"
+THERMO_MESH = (5, 5, 5)
+SUPERCELL = (4, 4, 4)
+REF_T_K = 14.0
+
+
+def _have_ne_fixture():
+    return (NE_IFC / "infile.forceconstant").exists() and \
+           (NE_IFC / "infile.ucposcar").exists()
+
+
+@pytest.fixture(scope="module")
+def ne_fc():
+    if not _have_ne_fixture():
+        pytest.skip("LJ Ne 14K_4UC fixture unavailable")
+    return ForceConstants.from_folder(
+        folder=str(NE_IFC), supercell=SUPERCELL, format="tdep", include_fourth=True,
+    )
+
+
+@pytest.mark.skipif(not _have_ne_fixture(), reason="LJ Ne 14K_4UC fixture unavailable")
+def test_parallel_F1_matches_serial(ne_fc):
+    masses = np.asarray(ne_fc.atoms.get_masses())
+    serial = F1_from_fc(
+        ne_fc, masses_amu=masses, kmesh=THERMO_MESH, T_K=REF_T_K,
+        use_q_symmetry=True, is_classic=False, n_workers=1,
+    )
+    parallel = F1_from_fc(
+        ne_fc, masses_amu=masses, kmesh=THERMO_MESH, T_K=REF_T_K,
+        use_q_symmetry=True, is_classic=False, n_workers=2,
+    )
+    for key in ("F1", "S1", "Cv1", "U1"):
+        np.testing.assert_allclose(
+            parallel[key], serial[key], rtol=1e-7,
+            err_msg=f"parallel F1 {key} drifted from serial",
+        )
+
+
+@pytest.mark.skipif(not _have_ne_fixture(), reason="LJ Ne 14K_4UC fixture unavailable")
+def test_parallel_F2_matches_serial(ne_fc):
+    masses = np.asarray(ne_fc.atoms.get_masses())
+    serial = F2_from_fc(
+        ne_fc, masses_amu=masses, kmesh=THERMO_MESH, T_K=REF_T_K,
+        sigma_THz=None, use_q_symmetry=True, is_classic=False, n_workers=1,
+    )
+    parallel = F2_from_fc(
+        ne_fc, masses_amu=masses, kmesh=THERMO_MESH, T_K=REF_T_K,
+        sigma_THz=None, use_q_symmetry=True, is_classic=False, n_workers=2,
+    )
+    for key in ("F2", "S2", "Cv2", "U2"):
+        np.testing.assert_allclose(
+            parallel[key], serial[key], rtol=1e-7,
+            err_msg=f"parallel F2 {key} drifted from serial",
+        )
+
+
+def test_parallel_harmonic_matches_serial(ne_fc):
+    """Phase-1 F_H/S_H on two processes matches the in-process Phonons loop."""
+    serial = _harmonic_thermo(
+        ne_fc, THERMO_MESH, T_K=REF_T_K, is_classic=False, n_workers=1,
+    )
+    parallel = _harmonic_thermo(
+        ne_fc, THERMO_MESH, T_K=REF_T_K, is_classic=False, n_workers=2,
+    )
+    for key in ("F_H", "U_H", "S_H", "Cv_H"):
+        np.testing.assert_allclose(
+            parallel[key], serial[key], rtol=1e-7,
+            err_msg=f"parallel harmonic {key} drifted from serial",
+        )
+
+
+def test_n_workers_zero_raises_F1(ne_fc):
+    masses = np.asarray(ne_fc.atoms.get_masses())
+    with pytest.raises(ValueError, match="n_workers must be >= 1"):
+        F1_from_fc(
+            ne_fc, masses_amu=masses, kmesh=(2, 2, 2), T_K=REF_T_K,
+            use_q_symmetry=True, n_workers=0,
+        )

--- a/kaldo/tests/test_parallel_cumulant.py
+++ b/kaldo/tests/test_parallel_cumulant.py
@@ -25,6 +25,96 @@ def _have_ne_fixture():
            (NE_IFC / "infile.ucposcar").exists()
 
 
+def test_quartet_mode_contraction_matches_scatter():
+    """Direct quartet-space Psi4 matches the original real-space scatter."""
+    from kaldo.cumulant.free_energy import (
+        _build_psi4_modes_quartet,
+        _build_psi4_modes_quartet_batch,
+        _prepare_psi4_q1,
+        build_psi4_realspace_v,
+    )
+
+    rng = np.random.default_rng(123)
+    n_quartets = 11
+    nb = 6
+    qd = {
+        "a1": rng.integers(0, 2, n_quartets, dtype=np.int32),
+        "a2": rng.integers(0, 2, n_quartets, dtype=np.int32),
+        "a3": rng.integers(0, 2, n_quartets, dtype=np.int32),
+        "a4": rng.integers(0, 2, n_quartets, dtype=np.int32),
+        "lv2c": rng.standard_normal((n_quartets, 3)),
+        "lv3c": rng.standard_normal((n_quartets, 3)),
+        "lv4c": rng.standard_normal((n_quartets, 3)),
+        "ifc": rng.standard_normal((n_quartets, 3, 3, 3, 3)),
+        "nb": nb,
+    }
+    q1 = rng.standard_normal(3)
+    q2 = rng.standard_normal(3)
+    M1 = rng.standard_normal((nb, nb, nb)) + 1j * rng.standard_normal((nb, nb, nb))
+    M2 = rng.standard_normal((nb, nb, nb)) + 1j * rng.standard_normal((nb, nb, nb))
+
+    A = build_psi4_realspace_v(qd, q1, q2)
+    tmp = np.einsum("kab,abcd->kcd", M1, A)
+    expected = np.einsum("kcd,lcd->kl", tmp, M2)
+    left_q1 = _prepare_psi4_q1(qd, M1, q1)
+    actual = _build_psi4_modes_quartet(qd, left_q1, M2, q2)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)
+
+    q2_batch = rng.standard_normal((4, 3))
+    M2_batch = rng.standard_normal((4, nb, nb, nb)) \
+        + 1j * rng.standard_normal((4, nb, nb, nb))
+    expected_batch = np.stack([
+        _build_psi4_modes_quartet(qd, left_q1, M2_batch[i], q2_batch[i])
+        for i in range(len(q2_batch))
+    ])
+    actual_batch = _build_psi4_modes_quartet_batch(
+        qd, left_q1, M2_batch, q2_batch,
+    )
+    np.testing.assert_allclose(actual_batch, expected_batch, rtol=1e-12, atol=1e-12)
+
+
+def test_triplet_mode_contraction_matches_scatter():
+    """Direct triplet-space Psi3 matches the original real-space scatter."""
+    from kaldo.cumulant.free_energy import (
+        _build_psi3_modes_triplet_batch,
+        _prepare_psi3_q1,
+        build_psi3_realspace,
+    )
+
+    rng = np.random.default_rng(456)
+    n_triplets = 13
+    nb = 6
+    td = {
+        "a1": rng.integers(0, 2, n_triplets, dtype=np.int32),
+        "a2": rng.integers(0, 2, n_triplets, dtype=np.int32),
+        "a3": rng.integers(0, 2, n_triplets, dtype=np.int32),
+        "lv2c": rng.standard_normal((n_triplets, 3)),
+        "lv3c": rng.standard_normal((n_triplets, 3)),
+        "ifc": rng.standard_normal((n_triplets, 3, 3, 3)),
+        "nb": nb,
+    }
+    batch = 4
+    q2 = rng.standard_normal((batch, 3))
+    q3 = rng.standard_normal((batch, 3))
+    e1 = rng.standard_normal((nb, nb)) + 1j * rng.standard_normal((nb, nb))
+    e2 = rng.standard_normal((batch, nb, nb)) \
+        + 1j * rng.standard_normal((batch, nb, nb))
+    e3 = rng.standard_normal((batch, nb, nb)) \
+        + 1j * rng.standard_normal((batch, nb, nb))
+
+    expected = []
+    for ib in range(batch):
+        A = build_psi3_realspace(td, q2[ib], q3[ib])
+        T1 = np.einsum("abc,ak->kbc", A, np.conj(e1))
+        T2 = np.einsum("kbc,bl->klc", T1, np.conj(e2[ib]))
+        expected.append(np.einsum("klc,cm->klm", T2, np.conj(e3[ib])))
+
+    left_q1 = _prepare_psi3_q1(td, e1)
+    actual = _build_psi3_modes_triplet_batch(td, left_q1, e2, e3, q2, q3)
+    np.testing.assert_allclose(actual, np.asarray(expected), rtol=1e-12, atol=1e-12)
+
+
 @pytest.fixture(scope="module")
 def ne_fc():
     if not _have_ne_fixture():

--- a/kaldo/tests/test_parallel_phase5.py
+++ b/kaldo/tests/test_parallel_phase5.py
@@ -1,0 +1,223 @@
+"""Phase-5 process-pool sampling: one calculator per worker.
+
+Serial ``n_workers=1`` is unchanged (existing thermo API tests). These
+tests cover ``n_workers>1``: fixed-displacement parity, jumped-stream
+sampling, unique LAMMPS logs, and ``n_workers=0`` rejection.
+
+Heavy TDEP IFC4 tables are not pickled into workers; unit tests use tiny
+synthetic contractors so spawn stays cheap.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ase import Atoms
+from ase.calculators.calculator import Calculator, all_changes
+from ase.calculators.lj import LennardJones
+
+from kaldo.cumulant.contractors import SCContractors
+from kaldo.cumulant.sampler import SCSampler
+from kaldo.parallel import get_executor
+
+AR_IFC = Path(__file__).parent / "cumulant_fixtures" / "LJ" / "Argon_80K_4UC"
+
+
+class _SpringCalc(Calculator):
+    """Analytic ASE calculator: E = 0.5 k * sum |r - r_ref|^2 (isotropic)."""
+
+    implemented_properties = ["energy", "free_energy"]
+
+    def __init__(self, r_ref, k=3.0):
+        super().__init__()
+        self._r_ref = np.array(r_ref, dtype=float)
+        self._k = float(k)
+
+    def calculate(self, atoms=None, properties=("energy",), system_changes=all_changes):
+        super().calculate(atoms, properties, system_changes)
+        du = atoms.get_positions() - self._r_ref
+        e = 0.5 * self._k * float(np.sum(du * du))
+        self.results = {"energy": e, "free_energy": e}
+
+
+def _have_ar():
+    return (AR_IFC / "infile.forceconstant").exists()
+
+
+def _lammps_importable():
+    try:
+        from ase.calculators.lammpslib import LAMMPSlib  # noqa: F401
+        import lammps  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _tiny_contractors(n_atoms=4):
+    """A few synthetic pairs/triplets/quartets — small enough to pickle."""
+    n_pair = 3
+    a1_2 = np.array([0, 1, 2], dtype=np.int64) % n_atoms
+    a2_2 = np.array([1, 2, 3], dtype=np.int64) % n_atoms
+    phi2 = np.repeat(0.2 * np.eye(3)[None, :, :], n_pair, axis=0)
+    n_tri = 2
+    a1_3 = np.array([0, 1], dtype=np.int64) % n_atoms
+    a2_3 = np.array([1, 2], dtype=np.int64) % n_atoms
+    a3_3 = np.array([2, 3], dtype=np.int64) % n_atoms
+    phi3 = np.zeros((n_tri, 3, 3, 3))
+    phi3[:, 0, 0, 0] = 0.05
+    n_q = 2
+    a1_4 = np.array([0, 1], dtype=np.int64) % n_atoms
+    a2_4 = np.array([1, 2], dtype=np.int64) % n_atoms
+    a3_4 = np.array([2, 3], dtype=np.int64) % n_atoms
+    a4_4 = np.array([3, 0], dtype=np.int64) % n_atoms
+    phi4 = np.zeros((n_q, 3, 3, 3, 3))
+    phi4[:, 0, 0, 0, 0] = 0.01
+    return SCContractors(_from_arrays=dict(
+        n_atoms_sc=n_atoms,
+        a1_2=a1_2, a2_2=a2_2, phi2=phi2,
+        a1_3=a1_3, a2_3=a2_3, a3_3=a3_3, phi3=phi3,
+        a1_4=a1_4, a2_4=a2_4, a3_4=a3_4, a4_4=a4_4, phi4=phi4,
+    ))
+
+
+def _einstein_sampler(n_atoms=4, seed=1):
+    k = 0.5
+    ifc2 = np.zeros((3 * n_atoms, 3 * n_atoms))
+    for i in range(n_atoms):
+        ifc2[3 * i:3 * i + 3, 3 * i:3 * i + 3] = k * np.eye(3)
+    masses = np.full(n_atoms, 40.0)
+    return SCSampler(ifc2, masses, T_K=80.0, is_classic=True, seed=seed)
+
+
+def _phase5_atoms(n_atoms=4):
+    rng = np.random.default_rng(0)
+    eq = rng.uniform(1.0, 4.0, size=(n_atoms, 3))
+    cell = np.eye(3) * 10.0
+    atoms = Atoms("Ar" * n_atoms, positions=eq, cell=cell, pbc=True)
+    return atoms, eq, cell
+
+
+def test_eval_u_chunk_parallel_matches_serial():
+    """Two process workers on a fixed ``u`` list match one-process evaluation."""
+    from kaldo.cumulant._phase5_worker import eval_u_chunk
+
+    n = 4
+    contractors = _tiny_contractors(n)
+    atoms, eq, cell = _phase5_atoms(n)
+    rng = np.random.default_rng(0)
+    us = 0.01 * rng.standard_normal((8, n, 3))
+    calc = _SpringCalc(eq, k=2.5)
+    base = dict(
+        contractors=contractors,
+        species=list(atoms.get_chemical_symbols()),
+        eq=eq,
+        cell=cell,
+        lammps_cmds=None,
+        calculator=calc,
+    )
+    serial = eval_u_chunk(dict(base, us=us))
+    mid = 4
+    specs = [dict(base, us=us[:mid]), dict(base, us=us[mid:])]
+    with get_executor(backend="process", n_workers=2) as executor:
+        futs = [executor.submit(eval_u_chunk, s) for s in specs]
+        parts = [f.result() for f in futs]
+    for i, key in enumerate(("V", "V2", "V3", "V4")):
+        got = np.concatenate([p[i] for p in parts])
+        np.testing.assert_allclose(
+            got, serial[i], rtol=1e-7, atol=1e-12,
+            err_msg=f"{key} parallel vs serial mismatch",
+        )
+
+
+def test_run_phase5_chunk_n_workers_2_finite():
+    """Jumped-stream shards return finite V/V2/V3/V4 (not bit-identical to serial)."""
+    from kaldo.cumulant._phase5_worker import run_phase5_chunk, run_phase5_loop
+    from kaldo.cumulant._energy_evaluator import BatchEnergyEvaluator
+
+    n = 4
+    nconf = 8
+    contractors = _tiny_contractors(n)
+    sampler = _einstein_sampler(n, seed=11)
+    atoms, eq, cell = _phase5_atoms(n)
+    atoms.calc = _SpringCalc(eq, k=2.5)
+    energy_eval = BatchEnergyEvaluator(atoms, eq)
+    serial = run_phase5_loop(nconf, sampler, contractors, energy_eval)
+
+    base = dict(
+        contractors=_tiny_contractors(n),
+        sampler=_einstein_sampler(n, seed=11),
+        species=list(atoms.get_chemical_symbols()),
+        eq=eq,
+        cell=cell,
+        lammps_cmds=None,
+        calculator=_SpringCalc(eq, k=2.5),
+        seed=11,
+    )
+    specs = [
+        dict(base, sampler=_einstein_sampler(n, seed=11), n_local=4, worker_id=0),
+        dict(base, sampler=_einstein_sampler(n, seed=11), n_local=4, worker_id=1),
+    ]
+    with get_executor(backend="process", n_workers=2) as executor:
+        futs = [executor.submit(run_phase5_chunk, s) for s in specs]
+        parts = [f.result() for f in futs]
+    V = np.concatenate([p[0] for p in parts])
+    assert V.shape == (nconf,)
+    assert np.all(np.isfinite(V))
+    assert np.all(np.isfinite(np.concatenate([p[1] for p in parts])))
+    assert np.all(np.isfinite(serial[0]))
+    # Jumped streams are independent of serial default_rng; not bit-identical.
+
+
+def test_cumulant_thermo_n_workers_zero_raises(tmp_path):
+    from kaldo.cumulant import cumulant_thermo
+    with pytest.raises(ValueError, match="n_workers"):
+        cumulant_thermo(
+            str(tmp_path), (1, 1, 1), 80.0, True,
+            calculator=object(), n_workers=0,
+        )
+
+
+@pytest.mark.skipif(not _have_ar(), reason="LJ Ar cumulant fixture missing")
+def test_cumulant_thermo_n_workers_2_ase_calculator():
+    """Phase 5 with two processes and ASE LJ: finite F0, no crash."""
+    from kaldo.cumulant import cumulant_thermo
+
+    r = cumulant_thermo(
+        str(AR_IFC), (4, 4, 4), temperature=80.0, is_classic=True,
+        calculator=LennardJones(epsilon=0.0104, sigma=3.4, rc=8.5),
+        nconf=8, nboot=16,
+        harmonic_mesh=(2, 2, 2), free_energy_mesh=(2, 2, 2),
+        use_q_symmetry=True, verbose=False, n_workers=2,
+    )
+    assert r.N_conf == 8
+    assert np.isfinite(r.F_0) and abs(r.F_0) < 1.0
+    assert np.all(np.isfinite(r.V)) and r.V.shape == (8,)
+    assert np.all(np.isfinite(r.V2)) and np.all(np.isfinite(r.V4))
+
+
+@pytest.mark.skipif(not _have_ar(), reason="LJ Ar cumulant fixture missing")
+@pytest.mark.skipif(not _lammps_importable(), reason="Python lammps module unavailable")
+def test_phase5_n_workers_2_lammps_smoke(tmp_path, monkeypatch):
+    """Two LAMMPS processes: unique logs, finite energies on a tiny sample."""
+    from kaldo.cumulant import cumulant_thermo
+
+    monkeypatch.setenv("KALDO_CUMULANT_LAMMPS_LOG_DIR", str(tmp_path))
+    r = cumulant_thermo(
+        str(AR_IFC), (4, 4, 4), temperature=80.0, is_classic=True,
+        lammps_cmds=[
+            "pair_style lj/cut 8.5",
+            "pair_coeff * * 0.0104 3.4",
+            "pair_modify shift yes",
+        ],
+        nconf=4, nboot=8,
+        harmonic_mesh=(2, 2, 2), free_energy_mesh=(2, 2, 2),
+        use_q_symmetry=True, verbose=False, n_workers=2,
+    )
+    assert np.isfinite(r.F_0)
+    assert r.V.shape == (4,)
+    assert np.all(np.isfinite(r.V))
+    logs = list(tmp_path.glob("cumulant_thermo_lammps_*.log"))
+    assert len(logs) >= 2
+    assert len({p.name for p in logs}) == len(logs)


### PR DESCRIPTION
Parallelizes the calculation of F1/F2 over the IBZ, parallelizes potential energy sampling by spawning multiple LAMMPS calculator instances, parallelizes harmonic Brillouin zone sum.

Runtime is down to ~30 minutes from 8.5 hours. Julia code is ~5 minutes still. 

The calculation of the potential energy (Phase 5) still seems to be a big bottleneck. About 600s here compared to 120s in Julia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable process-based parallelism for harmonic calculations, free-energy evaluations, and Phase-5 sampling.
  * Added the `n_workers` option to cumulant thermodynamics and related free-energy APIs.
  * Improved adaptive quantum smearing using Brillouin-zone geometry and analytical group velocities.
  * Added parallel support for calculator-based and sampling workflows.

* **Bug Fixes**
  * Improved handling of empty interaction data and thermodynamic table formatting.
  * Updated quantum reference values for affected Neon calculations.

* **Tests**
  * Added regression coverage comparing parallel and serial results and validating worker-count errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->